### PR TITLE
Fix typo in or1k success injection

### DIFF
--- a/linux/or1k/set_error.c
+++ b/linux/or1k/set_error.c
@@ -6,7 +6,7 @@ arch_set_error(struct tcb *tcp)
 }
 
 static int
-arch_setsuccess(struct tcb *tcp)
+arch_set_success(struct tcb *tcp)
 {
 	or1k_regs.gpr[11] = tcp->u_rval;
 	return set_regs(tcp->pid);


### PR DESCRIPTION
This fixes a typo in the arch_set_success for the or1k architecture.