### PR TITLE
MIPS strace Android/clang fixes

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -1041,10 +1041,12 @@ scno_is_valid(kernel_ulong_t scno)
  * kernel-userspace ABI and now must be maintained forever.  This matches
  * what the kernel exports for each architecture so we don't need to cast
  * every printing of __u64 or __s64 to stdint types.
+ * The exception is Android, where for MIPS64 unsigned long long is used.
  */
 #if SIZEOF_LONG == 4
 # define PRI__64 "ll"
-#elif defined ALPHA || defined IA64 || defined MIPS || defined POWERPC
+#elif defined ALPHA || defined IA64 || defined POWERPC || \
+      (defined MIPS && !defined __ANDROID__)
 # define PRI__64 "l"
 #else
 # define PRI__64 "ll"

--- a/linux/alpha/arch_regs.h
+++ b/linux/alpha/arch_regs.h
@@ -3,3 +3,5 @@
 #define REG_A3 19
 #define REG_FP 30
 #define REG_PC 64
+
+#define ARCH_USE_NEGATED_ERRNO

--- a/linux/mips/arch_regs.h
+++ b/linux/mips/arch_regs.h
@@ -1,3 +1,4 @@
+
 struct mips_regs {
 	uint64_t uregs[38];
 };
@@ -16,3 +17,5 @@ extern struct mips_regs mips_regs;
 #define mips_REG_A5 mips_regs.uregs[REG_A0 + 5]
 #define mips_REG_SP mips_regs.uregs[29]
 #define mips_REG_EPC mips_regs.uregs[34]
+
+#define ARCH_USE_NEGATED_ERRNO

--- a/linux/nios2/arch_regs.h
+++ b/linux/nios2/arch_regs.h
@@ -1,1 +1,3 @@
 extern unsigned int *const nios2_sp_ptr;
+
+#define ARCH_USE_NEGATED_ERRNO

--- a/linux/powerpc/arch_regs.h
+++ b/linux/powerpc/arch_regs.h
@@ -1,1 +1,3 @@
 extern struct pt_regs ppc_regs;
+
+#define ARCH_USE_NEGATED_ERRNO

--- a/linux/sparc/arch_regs.h
+++ b/linux/sparc/arch_regs.h
@@ -5,3 +5,5 @@ extern struct pt_regs sparc_regs;
 #define U_REG_O0 7
 #define U_REG_O1 8
 #define U_REG_FP 13
+
+#define ARCH_USE_NEGATED_ERRNO

--- a/syscall.c
+++ b/syscall.c
@@ -1047,6 +1047,7 @@ restore_cleared_syserror(struct tcb *tcp)
 	tcp->u_error = saved_u_error;
 }
 
+#ifndef ARCH_USE_NEGATED_ERRNO
 /*
  * Check the syscall return value register value for whether it is
  * a negated errno code indicating an error, or a success return value.
@@ -1066,6 +1067,7 @@ is_negated_errno(kernel_ulong_t val)
 
 	return val >= max;
 }
+#endif
 
 #include "arch_regs.c"
 


### PR DESCRIPTION
This pull request contains fixes for MIPS64 strace issues discovered when compiled using clang at AOSP.

Details regarding issues can be found in each patch commit message:
4fd0dfa Remove is_negated_errno() for archs which use negated syscall errno semantics
c25ac95 MIPS64: Fix PRI__64 macro definition when compiled for Android

The fixes were tested and do not introduce any issues when strace is compiled with both GCC/Clang and run on Linux platforms.