### PR TITLE
tests: stop passing invalid ops to futex_op_wake

### DIFF
--- a/tests/futex.c
+++ b/tests/futex.c
@@ -516,8 +516,8 @@ main(int argc, char *argv[])
 			"FUTEX_OP_CMP_EQ<<24|0", ENOSYS, "ENOSYS" },
 		{ 0x80000000, "FUTEX_OP_OPARG_SHIFT<<28|FUTEX_OP_SET<<28|0<<12|"
 			"FUTEX_OP_CMP_EQ<<24|0" },
-		{ 0xa0caffee, "FUTEX_OP_OPARG_SHIFT<<28|FUTEX_OP_OR<<28|"
-			"0xcaf<<12|FUTEX_OP_CMP_EQ<<24|0xfee" },
+		{ 0xa000ffee, "FUTEX_OP_OPARG_SHIFT<<28|FUTEX_OP_OR<<28|"
+			"0xf<<12|FUTEX_OP_CMP_EQ<<24|0xfee" },
 		{ 0x01000000, "FUTEX_OP_SET<<28|0<<12|FUTEX_OP_CMP_NE<<24|0" },
 		{ 0x01234567, "FUTEX_OP_SET<<28|0x234<<12|FUTEX_OP_CMP_NE<<24|"
 			"0x567" },
@@ -533,11 +533,11 @@ main(int argc, char *argv[])
 			"0x8<<24 /* FUTEX_OP_CMP_??? */|0", ENOSYS, "ENOSYS" },
 		{ 0x0f000000, "FUTEX_OP_SET<<28|0<<12|"
 			"0xf<<24 /* FUTEX_OP_CMP_??? */|0", ENOSYS, "ENOSYS" },
-		{ 0xbadfaced, "FUTEX_OP_OPARG_SHIFT<<28|FUTEX_OP_ANDN<<28|"
-			"0xdfa<<12|0xa<<24 /* FUTEX_OP_CMP_??? */|0xced",
+		{ 0xba00aced, "FUTEX_OP_OPARG_SHIFT<<28|FUTEX_OP_ANDN<<28|"
+			"0xa<<12|0xa<<24 /* FUTEX_OP_CMP_??? */|0xced",
 			ENOSYS, "ENOSYS" },
-		{ 0xffffffff, "FUTEX_OP_OPARG_SHIFT<<28|"
-			"0x7<<28 /* FUTEX_OP_??? */|0xfff<<12|"
+		{ 0xff01ffff, "FUTEX_OP_OPARG_SHIFT<<28|"
+			"0x7<<28 /* FUTEX_OP_??? */|0x1f<<12|"
 			"0xf<<24 /* FUTEX_OP_CMP_??? */|0xfff",
 			ENOSYS, "ENOSYS" },
 	};


### PR DESCRIPTION
Kernel 4.14-rc1 (commit https://github.com/torvalds/linux/commit/30d6e0a4190d) started checking op parameter to
futex_op_wake and strace tests started failing due to that:
```
FAIL: futex
===========

futex(0x7fabd78bcffc, 0x5, 0xfacefeed, 0xb, 0x7fabd78bcffc, 0xa0caffee) = -1: Invalid argument
futex.test: failed test: ../futex failed with code 1
```
0xa0caffee decodes as:
`0x80000000 & 0xa0caffee`: oparg is shift
`0x70000000 & 0xa0caffee`: op is FUTEX_OP_OR
`0x0f000000 & 0xa0caffee`: cmp is FUTEX_OP_CMP_EQ
`0x00fff000 & 0xa0caffee`: oparg is sign-extended 0xcaf = -849
`0x00000fff & 0xa0caffee`: cmparg is sign-extended 0xfee = -18

That means the op tries to do this:
```
	(futex |= (1 << (-849))) == -18
```
which is completely bogus. The new check of op in the code is:
```
	if (encoded_op & (FUTEX_OP_OPARG_SHIFT << 28)) {
	    if (oparg < 0 || oparg > 31)
		    return -EINVAL;
	    oparg = 1 << oparg;
	}
```
which results obviously in the "Invalid argument" errno above.

The kernel will soften the failure to print only a (ratelimited)
message, but the tests should be fixed so that we can enforce the error
in the future again.