### PR TITLE
a Ubuntu error when using 'INSTALL' to install

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -45,7 +45,9 @@ may remove or edit it.
    The file 'configure.ac' (or 'configure.in') is used to create
 'configure' by a program called 'autoconf'.  You need 'configure.ac' if
 you want to change it or regenerate 'configure' using a newer version of
-'autoconf'.
+'autoconf'. Note that if you are using Ubuntu, you need install 'libtool'
+otherwise there is a error "possibly undefined macro: AM_INIT_AUTOMAKE" 
+etc.
 
    The simplest way to compile this package is:
 


### PR DESCRIPTION
My programming environment is UBuntu 14.04 x86_64 GNU/Linux. When I use the '/strace' directory 'INSTALL' to install, the following error occurs:
"configure.ac:45: error: possibly undefined macro: AM_INIT_AUTOMAKE
       If this token and others are legitimate, please use m4_pattern_allow.
       See the Autoconf documentation.
Configure.ac:46: error: possibly undefined macro: AM_MAINTAINER_MODE
Configure.ac:902: error: possibly undefined macro: AM_CONDITIONAL”

I used the command "apt-get install libtool" and it was installed successfully. I recorded this error in the 48th line of "INSTALL" 'Note that if you are using Ubuntu, you need install 'libtool',
  Otherwise there is a error "possibly undefined macro: AM_INIT_AUTOMAKE" etc. ”
This problem is common in many Ubuntu distributions such as Ubuntu 16.04 and Ubuntu 14.04.
I hope this record will enable subsequent Ubuntu users to successfully install strace.