### PR TITLE
Make the build reproducible

### DIFF
--- a/file-date-gen
+++ b/file-date-gen
@@ -20,6 +20,11 @@ date=
 
 [ -f "${DATE_FILE}" ] && date="$(cat "${DATE_FILE}")"
 
+# Use SOURCE_DATE_EPOCH if it exists.
+# <https://reproducible-builds.org/specs/source-date-epoch/>
+[ -n "${SOURCE_DATE_EPOCH}" ] ||
+	date="@${SOURCE_DATE_EPOCH}"
+
 [ -n "${date}" ] ||
 	date="$(git log -n 1 --format=format:%cD --no-patch "${FILE}")"
 
@@ -32,4 +37,4 @@ date=
 	exit 1
 }
 
-exec printf "%s" $(date "+${DATE_FORMAT}" -d "${date}")
+exec printf "%s" $(date -u "+${DATE_FORMAT}" -d "${date}")


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/), we noticed that strace could not be built reproducibly. This is due to the documentation encodes a timezone-varying date in the manpages.

(This was originally filed in Debian as [#896016](https://bugs.debian.org/896016).)