### PR TITLE
Fix bionic (Android) build.

### DIFF
--- a/linux/linux/signal.h
+++ b/linux/linux/signal.h
@@ -1,5 +1,13 @@
+#include <sys/cdefs.h>
+#if defined(__BIONIC__)
+/*
+ * Bionic's <linux/signal.h> is the UAPI one, and <signal.h> requires it.
+ */
+#include_next <linux/signal.h>
+#else
 /*
  * Workaround the infamous incompatibility between <linux/signal.h>
  * and many libc headers by overriding <linux/signal.h> with <signal.h>.
  */
 #include <signal.h>
+#endif


### PR DESCRIPTION
b27397a7d2d665bc88a0c4b763e00cbb5812a28b breaks Android's libc because it
relies on the UAPI headers (such as <linux/signal.h>) to define various
types, rather than copying them into the libc headers (such as <signal.h>)
like most other Linux C libraries.