### PR TITLE
Add wildcard path matching option -W

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -473,6 +473,7 @@ extern struct path_set {
 	size_t size;
 } global_path_set;
 # define tracing_paths (global_path_set.num_selected != 0)
+extern unsigned enable_wildcard_path_matching;
 extern unsigned xflag;
 extern unsigned followfork;
 # ifdef ENABLE_STACKTRACE

--- a/strace.c
+++ b/strace.c
@@ -1650,7 +1650,7 @@ init(int argc, char *argv[])
 #ifdef ENABLE_STACKTRACE
 	    "k"
 #endif
-	    "a:Ab:cCdDe:E:fFhiI:o:O:p:P:qrs:S:tTu:vVwxX:yzZ";
+	    "a:Ab:cCdDe:E:fFhiI:o:O:p:P:qrs:S:tTu:vVwWxX:yzZ";
 
 	enum {
 		SECCOMP_OPTION = 0x100
@@ -1771,6 +1771,9 @@ init(int argc, char *argv[])
 			break;
 		case 'w':
 			count_wallclock = 1;
+			break;
+		case 'W':
+			enable_wildcard_path_matching = 1;
 			break;
 		case 'x':
 			xflag++;


### PR DESCRIPTION
This is a rough POC for allowing wildcard based path matching in strace for the path filters. It's mainly intended to support matching any files below in certain directory trees. Any ideas how to do something like this properly given the twofold nature of paths encountered by strace: via open(at) arguments and fds?