### PR TITLE
fix modify_ldt failed beacause of no error info 

### DIFF
--- a/tests/modify_ldt.c
+++ b/tests/modify_ldt.c
@@ -32,8 +32,10 @@ printrc(long rc)
 	 * Hopefully, we don't expect EPERM to be returned,
 	 * otherwise we can't distinguish it on x32.
 	 */
-	if (rc != -1 && err > 0 && err < 0x1000) {
-		errno = err;
+	if (err > 0 && err < 0x1000) {
+		if (rc != -1) {
+			errno = err;
+		}
 		printf(" %s (%m)", errno2name());
 	}
 # else


### PR DESCRIPTION
modify_ldt(0, NULL, 0) = -1
modify_ldt(-629534633, 0xffffffffffffffff, 16045756814261206767) = -1
modify_ldt(-629534633, 0x7f354d38a000, 0) = -1
modify_ldt(-629534633, 0x7f354d389ff0, 42) = -1
modify_ldt(-629534633, 0x7f354d38a000, 16) = -1
modify_ldt(-629534633, 0x7f354d1bbffc, 16) = -1
modify_ldt(-629534633, {entry_number=2206368128, base_addr=0x87868584,
limit=0x8b8a8988, seg_32bit=0, contents=2, read_exec_only=1,
limit_in_pages=0, seg_not_present=0, useable=0, lm=1}, 16) = -1
modify_ldt(-629534633, {entry_number=-1, base_addr=00000000,
limit=00000000, seg_32bit=1, contents=0, read_exec_only=0,
limit_in_pages=0, seg_not_present=1, useable=1, lm=0}, 16) = -1