### PR TITLE
ptrace_syscall_info.c: fix build without fork

### DIFF
--- a/ptrace_syscall_info.c
+++ b/ptrace_syscall_info.c
@@ -20,18 +20,20 @@
 
 bool ptrace_get_syscall_info_supported;
 
+#define FAIL	do { ptrace_stop = -1U; goto done; } while (0)
+
+#ifdef HAVE_FORK
 static int
 kill_tracee(pid_t pid)
 {
 	return kill_save_errno(pid, SIGKILL);
 }
 
-#define FAIL	do { ptrace_stop = -1U; goto done; } while (0)
-
 static const unsigned int expected_none_size =
 	offsetof(struct_ptrace_syscall_info, entry);
 static const unsigned int expected_entry_size =
 	offsetofend(struct_ptrace_syscall_info, entry.args);
+#endif /* HAVE_FORK */
 static const unsigned int expected_exit_size =
 	offsetofend(struct_ptrace_syscall_info, exit.is_error);
 static const unsigned int expected_seccomp_size =


### PR DESCRIPTION
Build without fork fails on:

```
ptrace_syscall_info.c:33:27: error: 'expected_entry_size' defined but not used [-Werror=unused-const-variable=]
 static const unsigned int expected_entry_size =
                           ^~~~~~~~~~~~~~~~~~~
ptrace_syscall_info.c:31:27: error: 'expected_none_size' defined but not used [-Werror=unused-const-variable=]
 static const unsigned int expected_none_size =
                           ^~~~~~~~~~~~~~~~~~
ptrace_syscall_info.c:24:1: error: 'kill_tracee' defined but not used [-Werror=unused-function]
 kill_tracee(pid_t pid)
 ^~~~~~~~~~~
```
Fixes:
 - http://autobuild.buildroot.org/results/ffc81d3798379a9c34c7a708ebbdea27409f755d

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>