### PR TITLE
Support interval specification in when-expression.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ Noteworthy changes in release ?.? (????-??-??)
   * Updated lists of BPF_* constants.
   * Added -e trace=%clock option for tracing syscalls reading of modifying
     system clocks.
+  * ":when=expr" subexpression now allows specifying last value of the
+    invocation range.
 
 Noteworthy changes in release 5.6 (2020-04-07)
 ==============================================

--- a/defs.h
+++ b/defs.h
@@ -230,6 +230,8 @@ typedef struct ioctlent {
 	|INJECT_F_DELAY_EXIT	\
 	)
 
+# define INJECT_LAST_INF (uint16_t)-1
+
 struct inject_data {
 	uint8_t flags;		/* 6 of 8 flags are used so far */
 	uint8_t signo;		/* NSIG <= 128 */
@@ -240,6 +242,7 @@ struct inject_data {
 
 struct inject_opts {
 	uint16_t first;
+	uint16_t last;
 	uint16_t step;
 	struct inject_data data;
 };

--- a/filter_qualify.c
+++ b/filter_qualify.c
@@ -417,6 +417,7 @@ qualify_inject_common(const char *const str,
 {
 	struct inject_opts opts = {
 		.first = 1,
+		.last = INJECT_LAST_INF,
 		.step = 1,
 		.data = {
 			.delay_idx = -1

--- a/strace.1.in
+++ b/strace.1.in
@@ -1265,15 +1265,35 @@ Unless a :\fBwhen\fR=\,\fIexpr\fR subexpression is specified,
 an injection is being made into every invocation of each syscall from the
 .IR set .
 .IP
-The format of the subexpression is one of the following:
+The format of the subexpression is:
+.RS 15
+.IP
+\fIfirst\/\fR[\fB,\fR\,\fIlast\/\fR][\fB+\fR[\,\fIstep\/\fR]]
+.RE
+.IP
+Number
+.I first
+stands for the first invocation number in the range, number
+.I last
+stands for the last invocation number in the range and
+.I step
+stands for the step between two consecutive invocations.
+Following combinations are useful:
 .RS
-.TP 12
+.TP 17
 .I first
 For every syscall from the
 .IR set ,
 perform an injection for the syscall invocation number
 .I first
 only.
+.TQ
+\fIfirst\/\fB,\fIlast\fR
+For every syscall from the
+.IR set ,
+perform an injection for the syscall invocation number
+.I first
+and all subsequent invocations until the invocation number \fIlast\fR.
 .TQ
 \fIfirst\/\fB+\fR
 For every syscall from the
@@ -1290,6 +1310,11 @@ perform injections for syscall invocations number
 .IR first + step ,
 .IR first + step + step ,
 and so on.
+.TQ
+\fIfirst\/\fB,\fIlast\fB+\fIstep\fR
+Same as previous, but consider only syscall invocations with numbers up to
+.I last
+(inclusive).
 .RE
 .IP
 For example, to fail each third and subsequent chdir syscalls with
@@ -1301,7 +1326,9 @@ The valid range for numbers
 .I first
 and
 .I step
-is 1..65535.
+is 1..65535 and for number
+.I last
+is 1..65534.
 .IP
 An injection expression can contain only one
 .BR error =

--- a/syscall.c
+++ b/syscall.c
@@ -491,10 +491,13 @@ tamper_with_syscall_entering(struct tcb *tcp, unsigned int *signo)
 
 	struct inject_opts *opts = tcb_inject_opts(tcp);
 
-	if (!opts || opts->first == 0)
+	if (!opts || opts->last == 0)
 		return 0;
 
 	--opts->first;
+
+	if (opts->last != INJECT_LAST_INF)
+		--opts->last;
 
 	if (opts->first != 0)
 		return 0;

--- a/tests/qual_fault-syntax.test
+++ b/tests/qual_fault-syntax.test
@@ -72,6 +72,13 @@ for arg in chdir:42 \!chdir:42 \
 	   chdir:syscall=-42 \
 	   chdir:syscall=42 \
 	   chdir:syscall=gettid:syscall=gettid \
+	   chdir:when=3,2 \
+	   chdir:when=2,3+0 \
+	   chdir:when=,5+2 \
+	   chdir:when=,5+ \
+	   chdir:when=,+ \
+	   chdir:when=+ \
+	   chdir:when=2,65535 \
 	   ; do
 	$STRACE -e fault="$arg" true 2> "$LOG" &&
 		fail_with "$arg"

--- a/tests/qual_fault.c
+++ b/tests/qual_fault.c
@@ -29,7 +29,7 @@ static int out_fd;
 #define DEFAULT_ERRNO ENOSYS
 
 static const char *errstr;
-static int is_raw, err, first, step, iter, try;
+static int is_raw, err, first, last, step, iter, try;
 
 static void
 invoke(int fail)
@@ -99,7 +99,7 @@ open_file(const char *prefix, int proc)
 int
 main(int argc, char *argv[])
 {
-	assert(argc == 11);
+	assert(argc == 12);
 
 	is_raw = !strcmp("raw", argv[1]);
 
@@ -120,13 +120,14 @@ main(int argc, char *argv[])
 	errstr = errno2name();
 
 	first = atoi(argv[3]);
-	step = atoi(argv[4]);
-	iter = atoi(argv[5]);
-	int num_procs = atoi(argv[6]);
-	char *exp_prefix = argv[7];
-	char *got_prefix = argv[8];
-	char *out_prefix = argv[9];
-	char *pid_prefix = argv[10];
+    last = atoi(argv[4]);
+	step = atoi(argv[5]);
+	iter = atoi(argv[6]);
+	int num_procs = atoi(argv[7]);
+	char *exp_prefix = argv[8];
+	char *got_prefix = argv[9];
+	char *out_prefix = argv[10];
+	char *pid_prefix = argv[11];
 
 	assert(first > 0);
 	assert(step >= 0);
@@ -164,8 +165,10 @@ main(int argc, char *argv[])
 		int i;
 		for (i = 1; i <= iter; ++i) {
 			int fail = 0;
-			if (first > 0) {
+			if (last != 0) {
 				--first;
+				if (last != -1)
+					--last;
 				if (first == 0) {
 					fail = 1;
 					first = step;

--- a/tests/qual_fault.test
+++ b/tests/qual_fault.test
@@ -32,8 +32,6 @@ check_fault_injection()
 	procs=$1; shift
 	extra="$*"
 
-	echo "RUNNING $first - $last - $step"
-
 	local when=
 	if [ -z "$first$last$step" ]; then
 		first=1

--- a/tests/qual_fault.test
+++ b/tests/qual_fault.test
@@ -22,24 +22,34 @@ N=100
 
 check_fault_injection()
 {
-	local trace fault err first step procs extra
+	local trace fault err first last step procs extra
 	trace=$1; shift
 	fault=$1; shift
 	err=$1; shift
 	first=$1; shift
+	last=$1; shift
 	step=$1; shift
 	procs=$1; shift
 	extra="$*"
 
+	echo "RUNNING $first - $last - $step"
+
 	local when=
-	if [ -z "$first$step" ]; then
+	if [ -z "$first$last$step" ]; then
 		first=1
+		last=-1
 		step=1
+	elif [ -z "$last" ] ; then
+		case "$step" in
+			'') when=":when=$first"; step=1; last=$first ;;
+			+) when=":when=$first+"; step=1; last=-1 ;;
+			*) when=":when=$first+$step"; last=-1; ;;
+		esac
 	else
 		case "$step" in
-			'') when=":when=$first"; step=0 ;;
-			+) when=":when=$first+"; step=1 ;;
-			*) when=":when=$first+$step" ;;
+			'') when=":when=$first,$last"; step=1 ;;
+			+) when=":when=$first,$last+"; step=1 ;;
+			*) when=":when=$first,$last+$step" ;;
 		esac
 	fi
 
@@ -63,7 +73,7 @@ check_fault_injection()
 
 	run_strace -a11 -ff -e trace=$trace \
 		"$@" -e fault=$fault$when$error$suffix $extra \
-		../$NAME $raw "$err" "$first" "$step" $N \
+		../$NAME $raw "$err" "$first" "$last" "$step" $N \
 		"$procs" "$outexp" "$outgot" "$outout" "$outpid"
 
 	for i in $(seq 0 $((procs - 1)) )
@@ -78,19 +88,39 @@ check_fault_injection()
 for err in '' ENOSYS 22 einval; do
 	for fault in writev desc,51; do
 		check_fault_injection \
-			writev $fault "$err" '' '' 1 -efault=chdir
+			writev $fault "$err" '' '' '' 1 -efault=chdir
 		check_fault_injection \
-			writev $fault "$err" '' '' 1 -efault=chdir -efault=none
+			writev $fault "$err" '' '' '' 1 -efault=chdir -efault=none
 		for F in 1 2 3 5 7 11; do
 			check_fault_injection \
-				writev $fault "$err" $F '' 1
+				writev $fault "$err" $F '' '' 1
 			check_fault_injection \
-				writev $fault "$err" $F + 1
+				writev $fault "$err" $F '' + 1
+
+			for L in 1 2 3 5 7 11; do
+				if [ "$L" -lt "$F" ] ; then
+					continue
+				fi
+				check_fault_injection \
+					writev $fault "$err" $F $L '' 1
+				check_fault_injection \
+					writev $fault "$err" $F $L + 1
+			done
+
 			for S in 1 2 3 5 7 11; do
 				check_fault_injection \
-					writev $fault "$err" $F $S 1
+					writev $fault "$err" $F '' $S 1
 				check_fault_injection \
-					writev $fault "$err" $F $S 4
+					writev $fault "$err" $F '' $S 4
+				for L in 1 2 3 5 7 11; do
+					if [ "$L" -lt "$F" ] ; then
+						continue
+					fi
+					check_fault_injection \
+						writev $fault "$err" $F $L $S 1
+					check_fault_injection \
+						writev $fault "$err" $F $L $S 4
+				done
 			done
 		done
 	done

--- a/tests/qual_inject-syntax.test
+++ b/tests/qual_inject-syntax.test
@@ -88,6 +88,13 @@ for arg in 42 chdir \
 	   chdir:syscall=-42 \
 	   chdir:syscall=42 \
 	   chdir:syscall=gettid:syscall=gettid \
+	   chdir:when=3,2 \
+	   chdir:when=2,3+0 \
+	   chdir:when=,5+2 \
+	   chdir:when=,5+ \
+	   chdir:when=,+ \
+	   chdir:when=+ \
+	   chdir:when=2,65535 \
 	   ; do
 	$STRACE -e inject="$arg" true 2> "$LOG" &&
 		fail_with "$arg"


### PR DESCRIPTION
Currently, strace allows syscall tampering only for syscall with 1) fixed invocation index or 2) all invocations starting from n-th (possibly with some step). 

Such two options do not cover a useful scenario of testing retrying/backoffing policy of traced program, which may be done by introducing delays/errors on first n invocations, and then stopping tampering.

This PR adds possibility to invoke strace like the following:

```
strace -e inject=recvfrom:delay_exit=100000:when=3,100 ./bin
```

which results in invocations from third to hundredth (inclusive) being tampered. Formally, syntax now looks like `when=first[,last][+step]`.

This change does not affect the existing behavior.