### PR TITLE
build: fix build with uclibc-ng

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -32,6 +32,7 @@
 # include <errno.h>
 # include <time.h>
 # include <sys/time.h>
+# include <dirent.h>
 
 # include "arch_defs.h"
 # include "error_prints.h"

--- a/mmsghdr.c
+++ b/mmsghdr.c
@@ -14,6 +14,10 @@
 #include "xstring.h"
 #include <limits.h>
 
+#ifndef IOV_MAX
+#define IOV_MAX	1024
+#endif
+
 static bool
 fetch_struct_mmsghdr_for_print(struct tcb *const tcp,
 				  const kernel_ulong_t addr,

--- a/msghdr.c
+++ b/msghdr.c
@@ -17,6 +17,10 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 
+#ifndef IOV_MAX
+#define IOV_MAX	1024
+#endif
+
 #define XLAT_MACROS_ONLY
 #include "xlat/sock_options.h"
 #undef XLAT_MACROS_ONLY


### PR DESCRIPTION
For building with uclibc-ng, 2 modifications are required:
1. adding `dirent.h` for PATH_MAX
2. defining an IOV_MAX value if undefined (uclibc-ng doesn't seem to have this defined in limits.h)

I'll admit that these fixes are not perfect, even half-assed.
But at least this can serve for some Google search to help others :)

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>