### PR TITLE
.gitignore: add missing files that should be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@
 /ChangeLog
 /INSTALL
 /README
+/TAGS
 /aclocal.m4
+/ar-lib
 /autom4te.cache
 /bpf_attr_check.c
 /compile
@@ -26,6 +28,7 @@
 /config.status
 /config.sub
 /configure
+/cscope.*
 /depcomp
 /gnu
 /install-sh
@@ -55,6 +58,7 @@
 /mx32_type_defs.h
 /native_printer_decls.h
 /native_printer_defs.h
+/ncscope.*
 /printers.h
 /scno.h
 /sen.h
@@ -68,6 +72,7 @@
 /strace.spec
 /sys_func.h
 /syscallent.i
+/tags
 /test-driver
 /tests-m32
 /tests-mx32


### PR DESCRIPTION
ar-lib is an autotools helper script.
tags, TAGS, cscope.* and ncscope.* are files generated by ctags and cscope,
source code analysers and navigation tools.