### PR TITLE
xlat: fix file descriptor closing typo

### DIFF
--- a/xlat/gen.sh
+++ b/xlat/gen.sh
@@ -375,7 +375,7 @@ gen_header()
 	EOF
 	) >"${output}"
 
-	exec 3>-
+	exec 3>&-
 }
 
 gen_make()


### PR DESCRIPTION
* xlat/gen.sh (gen_header): Replace 3>- with 3>&-.