### PR TITLE
readelf --debug-dump=info --wide output changes in 2.36

### DIFF
--- a/mpers.sh
+++ b/mpers.sh
@@ -46,7 +46,7 @@ for m_type; do
 		continue
 	sed -i -e '/DEF_MPERS_TYPE/d' "${f_c}"
 	$CC $CFLAGS $CC_ARCH_FLAG "${f_c}" -o "${f_o}"
-	$READELF --wide --debug-dump=info "${f_o}" > "${f_d1}"
+	$READELF --debug-dump=info "${f_o}" > "${f_d1}"
 	sed -r -n '
 		/^[[:space:]]*<1>/,/^[[:space:]]*<1><[^>]+>: Abbrev Number: 0/!d
 		/^[[:space:]]*<[^>]*><[^>]*>: Abbrev Number: 0/d


### PR DESCRIPTION
As seen here https://sourceware.org/bugzilla/show_bug.cgi?id=27309
the output format is changed. Not using --wide mode fixes the problem.