### PR TITLE
tests/pc: avoid program from creating a coredump

### DIFF
--- a/tests/pc.c
+++ b/tests/pc.c
@@ -14,6 +14,7 @@
 #include <sys/mman.h>
 #include <sys/wait.h>
 #include <sys/sendfile.h>
+#include <sys/prctl.h>
 
 int main(void)
 {
@@ -57,6 +58,9 @@ int main(void)
 			addr -= size;
 			size <<= 1;
 		}
+
+		/* Avoid creating core dumps */
+		(void) prctl(PR_SET_DUMPABLE, 0, 0, 0, 0);
 
 		/* SIGSEGV is expected */
 		(void) munmap((void *) addr, size);


### PR DESCRIPTION
Currently the `pc` test creates a coredump, which pollutes the `/var/lib/systemd/coredump` directory.

This patch proposes to avoid creating the coredump by changing the limit to 0.
Still `systemd-coredump` detects the SEGFAULT and records it in the journal, but at least there is no coredump effectively created.