### PR TITLE
Implement futex_waitv syscall decoding

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ Noteworthy changes in release ?.?? (????-??-??)
 * Improvements
   * Implemented --secontext=mismatch option to find mismatches in SELinux
     contexts.
+  * Implemented decoding of futex_waitv syscall introduced in Linux 5.16.
   * Implemented decoding of BPF_LINK_GET_NEXT_ID and BPF_LINK_GET_FD_BY_ID bpf
     syscall commands.
   * Enhanced decoding of BPF_MAP_CREATE, BPF_PROG_TEST_RUN, and BPF_PROG_LOAD

--- a/bundled/Makefile.am
+++ b/bundled/Makefile.am
@@ -38,6 +38,7 @@ EXTRA_DIST = \
 	linux/include/uapi/linux/fiemap.h \
 	linux/include/uapi/linux/fs.h \
 	linux/include/uapi/linux/fscrypt.h \
+	linux/include/uapi/linux/futex.h \
 	linux/include/uapi/linux/gen_stats.h \
 	linux/include/uapi/linux/gpio.h \
 	linux/include/uapi/linux/hiddev.h \

--- a/bundled/linux/include/uapi/linux/futex.h
+++ b/bundled/linux/include/uapi/linux/futex.h
@@ -1,0 +1,180 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+#ifndef _LINUX_FUTEX_H
+#define _LINUX_FUTEX_H
+
+
+#include <linux/types.h>
+
+/* Second argument to futex syscall */
+
+
+#define FUTEX_WAIT		0
+#define FUTEX_WAKE		1
+#define FUTEX_FD		2
+#define FUTEX_REQUEUE		3
+#define FUTEX_CMP_REQUEUE	4
+#define FUTEX_WAKE_OP		5
+#define FUTEX_LOCK_PI		6
+#define FUTEX_UNLOCK_PI		7
+#define FUTEX_TRYLOCK_PI	8
+#define FUTEX_WAIT_BITSET	9
+#define FUTEX_WAKE_BITSET	10
+#define FUTEX_WAIT_REQUEUE_PI	11
+#define FUTEX_CMP_REQUEUE_PI	12
+#define FUTEX_LOCK_PI2		13
+
+#define FUTEX_PRIVATE_FLAG	128
+#define FUTEX_CLOCK_REALTIME	256
+#define FUTEX_CMD_MASK		~(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME)
+
+#define FUTEX_WAIT_PRIVATE	(FUTEX_WAIT | FUTEX_PRIVATE_FLAG)
+#define FUTEX_WAKE_PRIVATE	(FUTEX_WAKE | FUTEX_PRIVATE_FLAG)
+#define FUTEX_REQUEUE_PRIVATE	(FUTEX_REQUEUE | FUTEX_PRIVATE_FLAG)
+#define FUTEX_CMP_REQUEUE_PRIVATE (FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG)
+#define FUTEX_WAKE_OP_PRIVATE	(FUTEX_WAKE_OP | FUTEX_PRIVATE_FLAG)
+#define FUTEX_LOCK_PI_PRIVATE	(FUTEX_LOCK_PI | FUTEX_PRIVATE_FLAG)
+#define FUTEX_LOCK_PI2_PRIVATE	(FUTEX_LOCK_PI2 | FUTEX_PRIVATE_FLAG)
+#define FUTEX_UNLOCK_PI_PRIVATE	(FUTEX_UNLOCK_PI | FUTEX_PRIVATE_FLAG)
+#define FUTEX_TRYLOCK_PI_PRIVATE (FUTEX_TRYLOCK_PI | FUTEX_PRIVATE_FLAG)
+#define FUTEX_WAIT_BITSET_PRIVATE	(FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG)
+#define FUTEX_WAKE_BITSET_PRIVATE	(FUTEX_WAKE_BITSET | FUTEX_PRIVATE_FLAG)
+#define FUTEX_WAIT_REQUEUE_PI_PRIVATE	(FUTEX_WAIT_REQUEUE_PI | \
+					 FUTEX_PRIVATE_FLAG)
+#define FUTEX_CMP_REQUEUE_PI_PRIVATE	(FUTEX_CMP_REQUEUE_PI | \
+					 FUTEX_PRIVATE_FLAG)
+
+/*
+ * Flags to specify the bit length of the futex word for futex2 syscalls.
+ * Currently, only 32 is supported.
+ */
+#define FUTEX_32		2
+
+/*
+ * Max numbers of elements in a futex_waitv array
+ */
+#define FUTEX_WAITV_MAX		128
+
+/**
+ * struct futex_waitv - A waiter for vectorized wait
+ * @val:	Expected value at uaddr
+ * @uaddr:	User address to wait on
+ * @flags:	Flags for this waiter
+ * @__reserved:	Reserved member to preserve data alignment. Should be 0.
+ */
+struct futex_waitv {
+	__u64 val;
+	__u64 uaddr;
+	__u32 flags;
+	__u32 __reserved;
+};
+
+/*
+ * Support for robust futexes: the kernel cleans up held futexes at
+ * thread exit time.
+ */
+
+/*
+ * Per-lock list entry - embedded in user-space locks, somewhere close
+ * to the futex field. (Note: user-space uses a double-linked list to
+ * achieve O(1) list add and remove, but the kernel only needs to know
+ * about the forward link)
+ *
+ * NOTE: this structure is part of the syscall ABI, and must not be
+ * changed.
+ */
+struct robust_list {
+	struct robust_list *next;
+};
+
+/*
+ * Per-thread list head:
+ *
+ * NOTE: this structure is part of the syscall ABI, and must only be
+ * changed if the change is first communicated with the glibc folks.
+ * (When an incompatible change is done, we'll increase the structure
+ *  size, which glibc will detect)
+ */
+struct robust_list_head {
+	/*
+	 * The head of the list. Points back to itself if empty:
+	 */
+	struct robust_list list;
+
+	/*
+	 * This relative offset is set by user-space, it gives the kernel
+	 * the relative position of the futex field to examine. This way
+	 * we keep userspace flexible, to freely shape its data-structure,
+	 * without hardcoding any particular offset into the kernel:
+	 */
+	long futex_offset;
+
+	/*
+	 * The death of the thread may race with userspace setting
+	 * up a lock's links. So to handle this race, userspace first
+	 * sets this field to the address of the to-be-taken lock,
+	 * then does the lock acquire, and then adds itself to the
+	 * list, and then clears this field. Hence the kernel will
+	 * always have full knowledge of all locks that the thread
+	 * _might_ have taken. We check the owner TID in any case,
+	 * so only truly owned locks will be handled.
+	 */
+	struct robust_list *list_op_pending;
+};
+
+/*
+ * Are there any waiters for this robust futex:
+ */
+#define FUTEX_WAITERS		0x80000000
+
+/*
+ * The kernel signals via this bit that a thread holding a futex
+ * has exited without unlocking the futex. The kernel also does
+ * a FUTEX_WAKE on such futexes, after setting the bit, to wake
+ * up any possible waiters:
+ */
+#define FUTEX_OWNER_DIED	0x40000000
+
+/*
+ * The rest of the robust-futex field is for the TID:
+ */
+#define FUTEX_TID_MASK		0x3fffffff
+
+/*
+ * This limit protects against a deliberately circular list.
+ * (Not worth introducing an rlimit for it)
+ */
+#define ROBUST_LIST_LIMIT	2048
+
+/*
+ * bitset with all bits set for the FUTEX_xxx_BITSET OPs to request a
+ * match of any bit.
+ */
+#define FUTEX_BITSET_MATCH_ANY	0xffffffff
+
+
+#define FUTEX_OP_SET		0	/* *(int *)UADDR2 = OPARG; */
+#define FUTEX_OP_ADD		1	/* *(int *)UADDR2 += OPARG; */
+#define FUTEX_OP_OR		2	/* *(int *)UADDR2 |= OPARG; */
+#define FUTEX_OP_ANDN		3	/* *(int *)UADDR2 &= ~OPARG; */
+#define FUTEX_OP_XOR		4	/* *(int *)UADDR2 ^= OPARG; */
+
+#define FUTEX_OP_OPARG_SHIFT	8	/* Use (1 << OPARG) instead of OPARG.  */
+
+#define FUTEX_OP_CMP_EQ		0	/* if (oldval == CMPARG) wake */
+#define FUTEX_OP_CMP_NE		1	/* if (oldval != CMPARG) wake */
+#define FUTEX_OP_CMP_LT		2	/* if (oldval < CMPARG) wake */
+#define FUTEX_OP_CMP_LE		3	/* if (oldval <= CMPARG) wake */
+#define FUTEX_OP_CMP_GT		4	/* if (oldval > CMPARG) wake */
+#define FUTEX_OP_CMP_GE		5	/* if (oldval >= CMPARG) wake */
+
+/* FUTEX_WAKE_OP will perform atomically
+   int oldval = *(int *)UADDR2;
+   *(int *)UADDR2 = oldval OP OPARG;
+   if (oldval CMP CMPARG)
+     wake UADDR2;  */
+
+#define FUTEX_OP(op, oparg, cmp, cmparg) \
+  (((op & 0xf) << 28) | ((cmp & 0xf) << 24)		\
+   | ((oparg & 0xfff) << 12) | (cmparg & 0xfff))
+
+#endif /* _LINUX_FUTEX_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -131,6 +131,7 @@ libstrace_a_SOURCES =	\
 	fstatfs.c \
 	fstatfs64.c \
 	futex.c		\
+	futex_waitv.c		\
 	gcc_compat.h	\
 	gen/gen_hdio.c	\
 	gen/generated.h	\

--- a/src/futex_waitv.c
+++ b/src/futex_waitv.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021-2022 The strace developers.
+ * Copyright (c) 2021 André Almeida <andrealmeid@collabora.com>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "defs.h"
+
+SYS_FUNC(futex_waitv)
+{
+	const kernel_ulong_t waiters = tcp->u_arg[0];
+	const unsigned int nr_futexes = tcp->u_arg[1];
+	const unsigned int flags = tcp->u_arg[2];
+	const kernel_ulong_t timeout = tcp->u_arg[3];
+	const unsigned int clockid = tcp->u_arg[4];
+
+	printaddr(waiters);
+	tprint_arg_next();
+	PRINT_VAL_U(nr_futexes);
+	tprint_arg_next();
+	PRINT_VAL_X(flags);
+	tprint_arg_next();
+	print_timespec64(tcp, timeout);
+	tprint_arg_next();
+	printxval(clocknames, clockid, "CLOCK_???");
+
+	return RVAL_DECODED;
+}

--- a/src/futex_waitv.c
+++ b/src/futex_waitv.c
@@ -7,6 +7,53 @@
  */
 
 #include "defs.h"
+#include <linux/futex.h>
+#include "xlat/futex_waiter_flags.h"
+
+struct print_waiter_data {
+	unsigned int count;
+};
+
+static bool
+print_waiter(struct tcb * const tcp, void * const elem_buf,
+	     const size_t elem_size, void * const data)
+{
+	struct futex_waitv *waiter = elem_buf;
+	struct print_waiter_data *p = data;
+
+	if (p->count++ >= FUTEX_WAITV_MAX) {
+		tprint_more_data_follows();
+		return false;
+	}
+
+	tprint_struct_begin();
+	PRINT_FIELD_X(*waiter, val);
+
+	tprint_struct_next();
+	PRINT_FIELD_ADDR64(*waiter, uaddr);
+
+	tprint_struct_next();
+	PRINT_FIELD_FLAGS(*waiter, flags, futex_waiter_flags, "FUTEX_???");
+
+	if (waiter->__reserved) {
+		tprint_struct_next();
+		PRINT_FIELD_X(*waiter, __reserved);
+	}
+
+	tprint_struct_end();
+	return true;
+}
+
+static void
+print_waiter_array(struct tcb * const tcp, const kernel_ulong_t waiters,
+		   const unsigned int nr_futexes)
+{
+	struct futex_waitv buf;
+	struct print_waiter_data data = {};
+
+	print_array(tcp, waiters, nr_futexes, &buf, sizeof(buf),
+		    tfetch_mem, print_waiter, &data);
+}
 
 SYS_FUNC(futex_waitv)
 {
@@ -16,7 +63,7 @@ SYS_FUNC(futex_waitv)
 	const kernel_ulong_t timeout = tcp->u_arg[3];
 	const unsigned int clockid = tcp->u_arg[4];
 
-	printaddr(waiters);
+	print_waiter_array(tcp, waiters, nr_futexes);
 	tprint_arg_next();
 	PRINT_VAL_U(nr_futexes);
 	tprint_arg_next();

--- a/src/linux/generic/syscallent-common.h
+++ b/src/linux/generic/syscallent-common.h
@@ -33,3 +33,4 @@
 [BASE_NR + 446] = { 2,	TD,		SEN(landlock_restrict_self),	"landlock_restrict_self"	},
 [BASE_NR + 447] = { 1,	TD,		SEN(memfd_secret),		"memfd_secret"			},
 [BASE_NR + 448] = { 2,	TD,		SEN(process_mrelease),		"process_mrelease"	},
+[BASE_NR + 449] = { 5,	0,		SEN(futex_waitv),		"futex_waitv"	},

--- a/src/xlat/futex_waiter_flags.in
+++ b/src/xlat/futex_waiter_flags.in
@@ -1,0 +1,3 @@
+#unconditional
+FUTEX_32
+FUTEX_PRIVATE_FLAG

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -170,6 +170,7 @@ fsync-y
 ftruncate
 ftruncate64
 futex
+futex_waitv
 futimesat
 gen_tests.am
 get_mempolicy

--- a/tests/futex_waitv.c
+++ b/tests/futex_waitv.c
@@ -1,0 +1,136 @@
+/*
+ * Check decoding of futex_waitv syscall.
+ *
+ * Copyright (c) 2015-2022 Dmitry V. Levin <ldv@strace.io>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "tests.h"
+#include "scno.h"
+#include "kernel_timespec.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include <linux/futex.h>
+
+static const char *errstr;
+
+static long
+k_futex_waitv(const void *const waiters,
+	      const unsigned int nr_futexes,
+	      const unsigned int flags,
+	      const void *const timeout,
+	      const unsigned int clockid)
+{
+	const kernel_ulong_t fill = (kernel_ulong_t) 0xdefaced00000000ULL;
+	const kernel_ulong_t bad = (kernel_ulong_t) 0xbadc0dedbadc0dedULL;
+	const kernel_ulong_t arg1 = (uintptr_t) waiters;
+	const kernel_ulong_t arg2 = fill | nr_futexes;
+	const kernel_ulong_t arg3 = fill | flags;
+	const kernel_ulong_t arg4 = (uintptr_t) timeout;
+	const kernel_ulong_t arg5 = fill | clockid;
+	const long rc = syscall(__NR_futex_waitv,
+				arg1, arg2, arg3, arg4, arg5, bad);
+	errstr = sprintrc(rc);
+	return rc;
+}
+
+int
+main(void)
+{
+	TAIL_ALLOC_OBJECT_CONST_PTR(uint32_t, futex);
+	TAIL_ALLOC_OBJECT_CONST_PTR(struct futex_waitv, waiter);
+	TAIL_ALLOC_OBJECT_CONST_PTR(kernel_timespec64_t, ts);
+	ts->tv_sec = 1;
+	ts->tv_nsec = 2;
+
+	k_futex_waitv(0, 1, -1U, 0, 1);
+	printf("futex_waitv(NULL, 1, %#x, NULL, CLOCK_MONOTONIC) = %s\n",
+	       -1U, errstr);
+
+	k_futex_waitv(waiter + 1, 0, 1, ts + 1, -1U);
+	printf("futex_waitv([], 0, %#x, %p, %#x /* CLOCK_??? */) = %s\n",
+	       1, ts + 1, -1U, errstr);
+
+	k_futex_waitv((void *) waiter + 1, 1, 0, ts, 0);
+	printf("futex_waitv(%p, 1, 0, {tv_sec=1, tv_nsec=2}, CLOCK_REALTIME)"
+	       " = %s\n",
+	       (void *) waiter + 1, errstr);
+
+	waiter->uaddr = 0;
+	k_futex_waitv(waiter, 1, 0, 0, 1);
+	printf("futex_waitv([{val=%#llx, uaddr=NULL, flags=%s|%#x"
+	       ", __reserved=%#x}], 1, 0, NULL, CLOCK_MONOTONIC) = %s\n",
+	       (unsigned long long) waiter->val,
+	       "FUTEX_32|FUTEX_PRIVATE_FLAG",
+	       waiter->flags & ~(FUTEX_32|FUTEX_PRIVATE_FLAG),
+	       waiter->__reserved, errstr);
+
+	waiter->val = 0xdeadbeeffacefeedULL;
+	waiter->uaddr = -1ULL;
+	waiter->flags = 0;
+	waiter->__reserved = 0;
+	k_futex_waitv(waiter, 1, 0, 0, 2);
+	printf("futex_waitv([{val=%#llx, uaddr=%#llx, flags=0}], 1, 0, NULL"
+	       ", CLOCK_PROCESS_CPUTIME_ID) = %s\n",
+	       (unsigned long long) waiter->val,
+	       (unsigned long long) waiter->uaddr,
+	       errstr);
+
+	waiter->val = 0;
+	waiter->uaddr = (uintptr_t) futex;
+	waiter->flags = FUTEX_PRIVATE_FLAG;
+	k_futex_waitv(waiter, 1, 0, 0, 0);
+	printf("futex_waitv([{val=0, uaddr=%p, flags=%s}], 1, 0, NULL"
+	       ", CLOCK_REALTIME) = %s\n",
+	       futex, "FUTEX_PRIVATE_FLAG", errstr);
+
+	waiter->flags = FUTEX_32;
+	k_futex_waitv(waiter, 2, 0, 0, 1);
+	printf("futex_waitv([{val=0, uaddr=%p, flags=%s}, ... /* %p */], 2, 0, NULL"
+	       ", CLOCK_MONOTONIC) = %s\n",
+	       futex, "FUTEX_32", waiter + 1, errstr);
+
+	waiter->flags = FUTEX_32|FUTEX_PRIVATE_FLAG;
+	k_futex_waitv(waiter, 1, 0, ts, 1);
+	printf("futex_waitv([{val=0, uaddr=%p, flags=%s}], 1, 0"
+	       ", {tv_sec=1, tv_nsec=2}, CLOCK_MONOTONIC) = %s\n",
+	       futex, "FUTEX_32|FUTEX_PRIVATE_FLAG", errstr);
+
+	unsigned int nr = FUTEX_WAITV_MAX + 1;
+	uint32_t * const futexes = tail_alloc(nr * sizeof(*futexes));
+	struct futex_waitv * const waiters = tail_alloc(nr * sizeof(*waiters));
+	for (unsigned int i = 0; i < nr; ++i) {
+		futexes[i] = i;
+		waiters[i].val = i;
+		waiters[i].uaddr = (uintptr_t) &futexes[i];
+		waiters[i].flags = FUTEX_32|FUTEX_PRIVATE_FLAG;
+		waiters[i].__reserved = 0;
+	}
+	k_futex_waitv(waiters, nr, 0, ts, 1);
+	printf("futex_waitv([");
+	for (unsigned int i = 0; i < FUTEX_WAITV_MAX; ++i) {
+		printf("%s{val=%#x, uaddr=%p, flags=%s}",
+		       i ? ", " : "",
+		       i, &futexes[i], "FUTEX_32|FUTEX_PRIVATE_FLAG");
+	}
+	printf(", ...], %u, 0, {tv_sec=1, tv_nsec=2}, CLOCK_MONOTONIC) = %s\n",
+	       nr, errstr);
+
+	nr = FUTEX_WAITV_MAX;
+	k_futex_waitv(waiters + 1, nr, 0, ts, 1);
+	printf("futex_waitv([");
+	for (unsigned int i = 0; i < FUTEX_WAITV_MAX; ++i) {
+		printf("%s{val=%#x, uaddr=%p, flags=%s}",
+		       i ? ", " : "",
+		       i + 1, &futexes[i + 1], "FUTEX_32|FUTEX_PRIVATE_FLAG");
+	}
+	printf("], %u, 0, {tv_sec=1, tv_nsec=2}, CLOCK_MONOTONIC) = %s\n",
+	       nr, errstr);
+
+	puts("+++ exited with 0 +++");
+	return 0;
+}

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -186,6 +186,7 @@ fsync	-a10
 fsync-y -y -e trace=fsync
 ftruncate	-a24
 ftruncate64	-a36
+futex_waitv	-s256
 futimesat	-a28
 get_mempolicy	-s3 -a38
 getcpu	-a25

--- a/tests/pure_executables.list
+++ b/tests/pure_executables.list
@@ -120,6 +120,7 @@ fsync
 ftruncate
 ftruncate64
 futex
+futex_waitv
 futimesat
 get_mempolicy
 getcpu


### PR DESCRIPTION
Hi,

This is an initial implementation of the new `futex_waitv()` syscall decoding that will be merged at Linux 5.16.

Documentation from the [commit message](https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/commit/?id=bf69bad38cf63d980e8a603f8d1bd1f85b5ed3d9):

Add support to wait on multiple futexes. This is the interface implemented by this syscall:

```
futex_waitv(struct futex_waitv *waiters, unsigned int nr_futexes,
	    unsigned int flags, struct timespec *timeout, clockid_t clockid)

struct futex_waitv {
	__u64 val;
	__u64 uaddr;
	__u32 flags;
	__u32 __reserved;
};
```

Given an array of `struct futex_waitv`, wait on each `uaddr`. The thread wakes if a `futex_wake()` is performed at any `uaddr`. The syscall returns immediately if any waiter has `*uaddr != val`. `*timeout` is an optional absolute timeout value for the operation. This syscall supports only 64bit sized timeout structs. The flags argument of the syscall should be empty, but it can be used for future extensions. Flags for shared futexes, sizes, etc. should be used on the individual flags of each waiter.

__reserved is used for explicit padding and should be 0, but it might be used for future extensions. If the userspace uses 32-bit pointers, it should make sure to explicitly cast it when assigning to `waitv::uaddr`.

Returns the array index of one of the woken futexes. There’s no given information of how many were woken, or any particular attribute of it (if it’s the first woken, if it is of the smaller index...).