### PR TITLE
tests: add #!/bin/sh where necessary

### DIFF
--- a/tests/qual_fault-syscall.test
+++ b/tests/qual_fault-syscall.test
@@ -1,3 +1,4 @@
+#!/bin/sh
 suffix=:syscall=gettid
 name_override=qual_fault
 . "${srcdir=.}/qual_fault.test"

--- a/tests/qual_inject-error-signal-syscall.test
+++ b/tests/qual_inject-error-signal-syscall.test
@@ -1,3 +1,4 @@
+#!/bin/sh
 suffix=:syscall=gettid
 name_override=qual_inject-error-signal
 . "${srcdir=.}/qual_inject-error-signal.test"

--- a/tests/qual_inject-retval-syscall.test
+++ b/tests/qual_inject-retval-syscall.test
@@ -1,3 +1,4 @@
+#!/bin/sh
 suffix=:syscall=gettid
 name_override=qual_inject-retval
 . "${srcdir=.}/qual_inject-retval.test"

--- a/tests/qual_inject-signal-syscall.test
+++ b/tests/qual_inject-signal-syscall.test
@@ -1,3 +1,4 @@
+#!/bin/sh
 suffix=:syscall=gettid
 name_override=qual_inject-signal
 . "${srcdir=.}/qual_inject-signal.test"


### PR DESCRIPTION
musl does not implement the shell fallback for execvpe, causing tests to
fail. it is also good practice to provide a shebang anyways.