### PR TITLE
Fix building for older Android

### DIFF
--- a/src/sync_file_range.c
+++ b/src/sync_file_range.c
@@ -9,6 +9,7 @@
 
 #include "defs.h"
 #include <fcntl.h>
+#include <linux/fs.h>
 #include "xlat/sync_file_range_flags.h"
 
 SYS_FUNC(sync_file_range)

--- a/src/sync_file_range2.c
+++ b/src/sync_file_range2.c
@@ -9,6 +9,7 @@
 
 #include "defs.h"
 #include <fcntl.h>
+#include <linux/fs.h>
 #include "xlat/sync_file_range_flags.h"
 
 SYS_FUNC(sync_file_range2)


### PR DESCRIPTION
With the following commands,
```
$ ./bootstrap
$ _pkg_arch=aarch64
$ export PATH="/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
$ CC=$_pkg_arch-linux-android21-clang \
  ./configure --prefix=/opt/android-libs/${_pkg_arch/_/-} \
    --host=$_pkg_arch-linux-android \
    --without-libunwind \
    --enable-mpers=no \
    --disable-gcc-Werror
$ make
```

Building fails with:
```
In file included from sync_file_range.c:12:
./xlat/sync_file_range_flags.h:7:16: error: use of undeclared identifier 'SYNC_FILE_RANGE_WAIT_BEFORE'
static_assert((SYNC_FILE_RANGE_WAIT_BEFORE) == (1), "SYNC_FILE_RANGE_WAIT_BEFORE != 1");
               ^
./xlat/sync_file_range_flags.h:10:16: error: use of undeclared identifier 'SYNC_FILE_RANGE_WRITE'
static_assert((SYNC_FILE_RANGE_WRITE) == (2), "SYNC_FILE_RANGE_WRITE != 2");
               ^
./xlat/sync_file_range_flags.h:13:16: error: use of undeclared identifier 'SYNC_FILE_RANGE_WAIT_AFTER'
static_assert((SYNC_FILE_RANGE_WAIT_AFTER) == (4), "SYNC_FILE_RANGE_WAIT_AFTER != 4");
               ^
./xlat/sync_file_range_flags.h:27:7: error: use of undeclared identifier 'SYNC_FILE_RANGE_WAIT_BEFORE'
 XLAT(SYNC_FILE_RANGE_WAIT_BEFORE),
      ^
./xlat/sync_file_range_flags.h:30:7: error: use of undeclared identifier 'SYNC_FILE_RANGE_WRITE'
 XLAT(SYNC_FILE_RANGE_WRITE),
      ^
./xlat/sync_file_range_flags.h:33:7: error: use of undeclared identifier 'SYNC_FILE_RANGE_WAIT_AFTER'
 XLAT(SYNC_FILE_RANGE_WAIT_AFTER),
      ^
./xlat/sync_file_range_flags.h:40:10: error: invalid application of 'sizeof' to an incomplete type 'const struct xlat_data []'
 .size = ARRAY_SIZE(sync_file_range_flags_xdata),
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./macros.h:18:32: note: expanded from macro 'ARRAY_SIZE'
# define ARRAY_SIZE(a_) (sizeof(a_) / sizeof((a_)[0]) + MUST_BE_ARRAY(a_))
                               ^~~~
In file included from sync_file_range.c:12:
./xlat/sync_file_range_flags.h:44:5: error: use of undeclared identifier 'SYNC_FILE_RANGE_WAIT_BEFORE'
  | XLAT_VAL_0
    ^
./xlat/sync_file_range_flags.h:28:34: note: expanded from macro 'XLAT_VAL_0'
 #define XLAT_VAL_0 ((unsigned) (SYNC_FILE_RANGE_WAIT_BEFORE))
                                 ^
./xlat/sync_file_range_flags.h:47:5: error: use of undeclared identifier 'SYNC_FILE_RANGE_WRITE'
  | XLAT_VAL_1
    ^
./xlat/sync_file_range_flags.h:31:34: note: expanded from macro 'XLAT_VAL_1'
 #define XLAT_VAL_1 ((unsigned) (SYNC_FILE_RANGE_WRITE))
                                 ^
./xlat/sync_file_range_flags.h:50:5: error: use of undeclared identifier 'SYNC_FILE_RANGE_WAIT_AFTER'
  | XLAT_VAL_2
    ^
./xlat/sync_file_range_flags.h:34:34: note: expanded from macro 'XLAT_VAL_2'
 #define XLAT_VAL_2 ((unsigned) (SYNC_FILE_RANGE_WAIT_AFTER))
                                 ^
10 errors generated.
```
This is a regression from bd87cc95120b3707a6fe55129451bb0453730a6d,
where "#unconditional" is added given that <linux/fs.h> is bundled,
but the latter is not actually included.

As a side note, SYNC_FILE_RANGE* symbols are not available with
ANDROID_API__ < 26 [1].

[1] https://android.googlesource.com/platform/bionic/+/refs/tags/android-12.0.0_r15/libc/include/fcntl.h#98