### PR TITLE
loongarch64: make use of the newly exposed orig_a0 field for ptrace

### DIFF
--- a/src/linux/loongarch64/arch_prstatus_regset.c
+++ b/src/linux/loongarch64/arch_prstatus_regset.c
@@ -20,6 +20,10 @@ arch_decode_prstatus_regset(struct tcb *const tcp,
 		PRINT_FIELD_ARRAY_UPTO(regs, regs,
 				       fetch_size / 8, tcp,
 				       print_xint_array_member);
+		if (fetch_size > offsetof(struct_prstatus_regset, orig_a0)) {
+			tprint_struct_next();
+			PRINT_FIELD_X(regs, orig_a0);
+		}
 		if (fetch_size > offsetof(struct_prstatus_regset, csr_era)) {
 			tprint_struct_next();
 			PRINT_FIELD_X(regs, csr_era);

--- a/src/linux/loongarch64/get_syscall_args.c
+++ b/src/linux/loongarch64/get_syscall_args.c
@@ -9,7 +9,7 @@
 static int
 arch_get_syscall_args(struct tcb *tcp)
 {
-	tcp->u_arg[0] = loongarch_regs.regs[4];
+	tcp->u_arg[0] = loongarch_regs.orig_a0;
 	tcp->u_arg[1] = loongarch_regs.regs[5];
 	tcp->u_arg[2] = loongarch_regs.regs[6];
 	tcp->u_arg[3] = loongarch_regs.regs[7];

--- a/tests/ptrace.c
+++ b/tests/ptrace.c
@@ -857,6 +857,10 @@ print_prstatus_regset(const void *const rs, const size_t size)
 		}
 		fputs("]", stdout);
 	}
+	if (size >= offsetofend(TRACEE_REGS_STRUCT, orig_a0)) {
+		fputs(", ", stdout);
+		PRINT_FIELD_X(*regs, orig_a0);
+	}
 	if (size >= offsetofend(TRACEE_REGS_STRUCT, csr_era)) {
 		fputs(", ", stdout);
 		PRINT_FIELD_X(*regs, csr_era);


### PR DESCRIPTION
(continuing from #205)

With the LoongArch `struct user_pt_regs` definition amended to [expose the `orig_a0` field](https://github.com/loongson/linux/blob/3643df5f058aacf69ac4121f6882500e843b7a34/arch/loongarch/include/uapi/asm/ptrace.h#L35), I've integrated the changes into [my kernel branch](https://github.com/xen0n/linux/commits/loongarch-playground-v11-draft) and passed the tests with this PR:

```
============================================================================
Testsuite summary for strace 5.16.0.37.1e18
============================================================================
# TOTAL: 1193
# PASS:  961
# SKIP:  232
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

`uname -a`: `Linux lily 5.17.0-rc1-12006-g03f57a04a4f1 #3 SMP PREEMPT Thu Nov 25 11:42:54 PM CST 2021 loongarch64 GNU/Linux`

@chenhuacai: Please update the kernel and corresponding headers for the cfarm boxes; so that maintainers can test this.