### PR TITLE
secontext: print context of Unix socket's sun_path field

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ Noteworthy changes in release ?.?? (????-??-??)
 ===============================================
 
 * Improvements
+  * Implemented printing of Unix socket sun_path field's SELinux context.
 
 * Bug fixes
 

--- a/src/sockaddr.c
+++ b/src/sockaddr.c
@@ -63,6 +63,8 @@
 #include "xlat/mctp_addrs.h"
 #include "xlat/mctp_nets.h"
 
+#include "secontext.h"
+
 #define SIZEOF_SA_FAMILY sizeof_field(struct sockaddr, sa_family)
 
 struct sockaddr_rxrpc {
@@ -115,6 +117,7 @@ print_sockaddr_data_un(struct tcb *tcp, const void *const buf, const int addrlen
 	if (sa_un->sun_path[0]) {
 		print_quoted_string(sa_un->sun_path, path_len + 1,
 				    QUOTE_0_TERMINATED);
+		selinux_printfilecon(tcp, sa_un->sun_path);
 	} else {
 		tprints("@");
 		print_quoted_string(sa_un->sun_path + 1, path_len - 1, 0);

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -225,6 +225,10 @@ getrusage	-v
 getsid	-a10
 getsid--pidns-translation	test_pidns -e trace=getsid -a10
 getsockname	-a27
+getsockname--secontext	-a27 --secontext -e trace=getsockname
+getsockname--secontext_full	-a27 --secontext=full -e trace=getsockname
+getsockname--secontext_full_mismatch	-a27 --secontext=full,mismatch -e trace=getsockname
+getsockname--secontext_mismatch	-a27 --secontext=mismatch -e trace=getsockname
 gettid	-a9
 getuid-creds	+getuid.test
 getuid32	+getuid.test

--- a/tests/secontext.h
+++ b/tests/secontext.h
@@ -9,9 +9,11 @@
 #include "xmalloc.h"
 #include <unistd.h>
 
+char *secontext_full_fd(int) ATTRIBUTE_MALLOC;
 char *secontext_full_file(const char *, bool) ATTRIBUTE_MALLOC;
 char *secontext_full_pid(pid_t) ATTRIBUTE_MALLOC;
 
+char *secontext_short_fd(int) ATTRIBUTE_MALLOC;
 char *secontext_short_file(const char *, bool) ATTRIBUTE_MALLOC;
 char *secontext_short_pid(pid_t) ATTRIBUTE_MALLOC;
 
@@ -30,6 +32,7 @@ enum secontext_field {
  */
 char *get_secontext_field(const char *full_context, enum secontext_field field);
 
+char *get_secontext_field_fd(int fd, enum secontext_field field);
 char *get_secontext_field_file(const char *file, enum secontext_field field);
 
 void reset_secontext_file(const char *file);
@@ -44,6 +47,7 @@ void update_secontext_field(const char *file, enum secontext_field field,
 #  else
 #   define SECONTEXT_FILE(filename)	secontext_full_file(filename, false)
 #  endif
+#  define SECONTEXT_FD(fd)		secontext_full_fd(fd)
 #  define SECONTEXT_PID(pid)		secontext_full_pid(pid)
 
 # else
@@ -53,6 +57,7 @@ void update_secontext_field(const char *file, enum secontext_field field,
 #  else
 #   define SECONTEXT_FILE(filename)	secontext_short_file(filename, false)
 #  endif
+#  define SECONTEXT_FD(fd)		secontext_short_fd(fd)
 #  define SECONTEXT_PID(pid)		secontext_short_pid(pid)
 
 # endif
@@ -64,6 +69,12 @@ get_secontext_field(const char *ctx, enum secontext_field field)
 {
 	return NULL;
 }
+static inline char *
+get_secontext_field_fd(int fd, enum secontext_field field)
+{
+	return NULL;
+}
+
 static inline char *
 get_secontext_field_file(const char *file, enum secontext_field field)
 {
@@ -81,6 +92,7 @@ update_secontext_field(const char *file, enum secontext_field field,
 {
 }
 
+# define SECONTEXT_FD(fd)			xstrdup("")
 # define SECONTEXT_FILE(filename)		xstrdup("")
 # define SECONTEXT_PID(pid)			xstrdup("")
 

--- a/tests/sockname.c
+++ b/tests/sockname.c
@@ -18,6 +18,8 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
+#include "secontext.h"
+
 #ifndef TEST_SYSCALL_NAME
 # error TEST_SYSCALL_NAME must be defined
 #endif
@@ -59,14 +61,19 @@ test_sockname_syscall(const int fd)
 	*plen = sizeof(struct sockaddr_un);
 	struct sockaddr_un *addr = tail_alloc(*plen);
 
+	char *my_secontext = SECONTEXT_PID_MY();
+	char *fd_secontext = SECONTEXT_FD(fd);
+
 	PREPARE_TEST_SYSCALL_INVOCATION;
 	int rc = TEST_SYSCALL_NAME(fd PREFIX_S_ARGS, (void *) addr,
 				   plen SUFFIX_ARGS);
 	if (rc < 0)
 		perror_msg_and_skip(TEST_SYSCALL_STR);
-	printf("%s(%d%s, {sa_family=AF_UNIX, sun_path=\"%s\"}"
+	printf("%s%s(%d%s%s, {sa_family=AF_UNIX, sun_path=\"%s\"%s}"
 	       ", [%d => %d]%s) = %d\n",
-	       TEST_SYSCALL_STR, fd, PREFIX_S_STR, addr->sun_path,
+	       my_secontext,
+	       TEST_SYSCALL_STR, fd, fd_secontext, PREFIX_S_STR,
+	       addr->sun_path, SECONTEXT_FILE(addr->sun_path),
 	       (int) sizeof(struct sockaddr_un), (int) *plen, SUFFIX_STR, rc);
 
 	memset(addr, 0, sizeof(*addr));
@@ -75,28 +82,34 @@ test_sockname_syscall(const int fd)
 			       plen SUFFIX_ARGS);
 	if (rc < 0)
 		perror_msg_and_skip(TEST_SYSCALL_STR);
-	printf("%s(%d%s, {sa_family=AF_UNIX, sun_path=\"%s\"}"
+	printf("%s%s(%d%s%s, {sa_family=AF_UNIX, sun_path=\"%s\"%s}"
 	       ", [%d]%s) = %d\n",
-	       TEST_SYSCALL_STR, fd, PREFIX_S_STR, addr->sun_path,
+	       my_secontext,
+	       TEST_SYSCALL_STR, fd, fd_secontext, PREFIX_S_STR,
+	       addr->sun_path, SECONTEXT_FILE(addr->sun_path),
 	       (int) *plen, SUFFIX_STR, rc);
 
 	PREPARE_TEST_SYSCALL_INVOCATION;
 	rc = TEST_SYSCALL_NAME(fd PREFIX_F_ARGS, (void *) addr, 0 SUFFIX_ARGS);
-	printf("%s(%d%s, %p, NULL%s) = %s\n",
-	       TEST_SYSCALL_STR, fd, PREFIX_F_STR, addr, SUFFIX_STR,
-	       sprintrc(rc));
+	printf("%s%s(%d%s%s, %p, NULL%s) = %s\n",
+	       my_secontext,
+	       TEST_SYSCALL_STR, fd, fd_secontext, PREFIX_F_STR,
+	       addr, SUFFIX_STR, sprintrc(rc));
 
 	PREPARE_TEST_SYSCALL_INVOCATION;
 	rc = TEST_SYSCALL_NAME(fd PREFIX_S_ARGS, 0, 0 SUFFIX_ARGS);
-	printf("%s(%d%s, NULL, NULL%s) = %s\n",
-	       TEST_SYSCALL_STR, fd, rc == -1 ? PREFIX_F_STR : PREFIX_S_STR,
+	printf("%s%s(%d%s%s, NULL, NULL%s) = %s\n",
+	       my_secontext,
+	       TEST_SYSCALL_STR, fd, fd_secontext,
+	       rc == -1 ? PREFIX_F_STR : PREFIX_S_STR,
 	       SUFFIX_STR, sprintrc(rc));
 
 	PREPARE_TEST_SYSCALL_INVOCATION;
 	rc = TEST_SYSCALL_NAME(fd PREFIX_F_ARGS, (void *) addr,
 			       plen + 1 SUFFIX_ARGS);
-	printf("%s(%d%s, %p, %p%s) = %s\n",
-	       TEST_SYSCALL_STR, fd, PREFIX_F_STR, addr,
+	printf("%s%s(%d%s%s, %p, %p%s) = %s\n",
+	       my_secontext,
+	       TEST_SYSCALL_STR, fd, fd_secontext, PREFIX_F_STR, addr,
 	       plen + 1, SUFFIX_STR, sprintrc(rc));
 
 	const size_t offsetof_sun_path = offsetof(struct sockaddr_un, sun_path);
@@ -108,8 +121,9 @@ test_sockname_syscall(const int fd)
 			       plen SUFFIX_ARGS);
 	if (rc < 0)
 		perror_msg_and_skip(TEST_SYSCALL_STR);
-	printf("%s(%d%s, {sa_family=AF_UNIX}, [%d => %d]%s) = %d\n",
-	       TEST_SYSCALL_STR, fd, PREFIX_S_STR,
+	printf("%s%s(%d%s%s, {sa_family=AF_UNIX}, [%d => %d]%s) = %d\n",
+	       my_secontext,
+	       TEST_SYSCALL_STR, fd, fd_secontext, PREFIX_S_STR,
 	       (int) offsetof_sun_path, (int) *plen, SUFFIX_STR, rc);
 
 	++addr;
@@ -121,17 +135,19 @@ test_sockname_syscall(const int fd)
 			       plen SUFFIX_ARGS);
 	if (rc < 0)
 		perror_msg_and_skip(TEST_SYSCALL_STR);
-	printf("%s(%d%s, {sa_family=AF_UNIX, sun_path=\"%.*s\"}"
+	printf("%s%s(%d%s%s, {sa_family=AF_UNIX, sun_path=\"%.*s\"%s}"
 	       ", [%d => %d]%s) = %d\n",
-	       TEST_SYSCALL_STR, fd, PREFIX_S_STR,
+	       my_secontext,
+	       TEST_SYSCALL_STR, fd, fd_secontext, PREFIX_S_STR,
 	       (int) (sizeof(struct sockaddr) - offsetof_sun_path),
-	       addr->sun_path, (int) sizeof(struct sockaddr),
-	       (int) *plen, SUFFIX_STR, rc);
+	       addr->sun_path, SECONTEXT_FILE(addr->sun_path),
+	       (int) sizeof(struct sockaddr), (int) *plen, SUFFIX_STR, rc);
 
 	PREPARE_TEST_SYSCALL_INVOCATION;
 	rc = TEST_SYSCALL_NAME(fd PREFIX_F_ARGS, (void *) addr,
 			       plen SUFFIX_ARGS);
-	printf("%s(%d%s, %p, [%d]%s) = %s\n",
-	       TEST_SYSCALL_STR, fd, PREFIX_F_STR, addr,
+	printf("%s%s(%d%s%s, %p, [%d]%s) = %s\n",
+	       my_secontext,
+	       TEST_SYSCALL_STR, fd, fd_secontext, PREFIX_F_STR, addr,
 	       *plen, SUFFIX_STR, sprintrc(rc));
 }


### PR DESCRIPTION
This patch prints context of `sun_path` field in Unix sockets, e.g.:
~~~
151020 [unconfined_t] 14:37:21.990449 connect(3<UNIX-STREAM:[524197]> [unconfined_t], {sa_family=AF_UNIX, sun_path="/run/dbus/system_bus_socket" [system_dbusd_var_run_t]}, 30) = 0 <0.000033>
~~~