### PR TITLE
mpers: add missing dependency on autogenerated sys_func.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1150,8 +1150,11 @@ libmpers_CFLAGS = $(strace_CFLAGS)
 
 # mpers targets
 
-mpers-m%.stamp: $(srcdir_mpers_source_files) | printers.h
-	for f in $^; do \
+# sys_func.h is an auto-generated file. Make sure it's present before
+# preprocessor is ran against it. Example use:
+#   struct_blk_user_trace_setup.c => syscall.h => sys_func.h (generated)
+mpers-m%.stamp: $(srcdir_mpers_source_files) printers.h sys_func.h
+	for f in $(srcdir_mpers_source_files); do \
 		D="$(D)" \
 		READELF="$(READELF)" \
 		CC="$(mpers_CC)" \


### PR DESCRIPTION
Noticed missing target directory dependency as a build failure in
`make --shuffle` mode (added in https://savannah.gnu.org/bugs/index.php?62100):

    for f in block.c ... v4l2.c; do \
            D="" \
            READELF="readelf" \
            CC="gcc" \
            CFLAGS="-DHAVE_CONFIG_H  ... -I./bundled/linux/include/uapi -DMPERS_IS_m32" \
            CPP="gcc -E" \
            CPPFLAGS="-DHAVE_CONFIG_H ... -DMPERS_IS_m32" \
            ./mpers.sh m32 "-m32" $f || exit; \
    done
    In file included from ./defs.h:2041,
                     from mpers-m32/struct_blk_user_trace_setup.c:10:
    ./syscall.h:14:11: fatal error: sys_func.h: No such file or directory
       14 | # include "sys_func.h"
          |           ^~~~~~~~~~~~

While at it changed order-only dependency against generated headers to
full dependency.