### PR TITLE
sysent: Provide proper function prototype to fix -Wdeprecated-non-prototype

### DIFF
--- a/src/sysent.h
+++ b/src/sysent.h
@@ -8,11 +8,13 @@
 #ifndef STRACE_SYSENT_H
 # define STRACE_SYSENT_H
 
+struct tcb;
+
 typedef struct sysent {
 	unsigned nargs;
 	int	sys_flags;
 	int	sen;
-	int	(*sys_func)();
+	int	(*sys_func)(struct tcb *);
 	const char *sys_name;
 } struct_sysent;
 


### PR DESCRIPTION
clang-15 emits an error because the `sys_func` function pointer of the sysent struct doesn't declare an argument list:

> make[3]: Entering directory '/home/marv/devel/strace/src'
> clang -DHAVE_CONFIG_H   -I./linux/x86_64 -I./linux/x86_64 -I./linux/generic -I./linux/generic -I. -I. -I../bundled/linux/arch/x86/include/uapi -I../bundled/linux/include/uapi -DIN_STRACE=1      -I./bundled/linux/arch/x86/include/uapi -I./bundled/linux/include/uapi -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -Wdate-time -Wformat-security -Winit-self -Winitializer-overrides -Wmissing-prototypes -Wnested-externs -Wold-style-definition -Wundef -Wwrite-strings -Werror   -Wall -g -ggdb3 -O0 -c -o libstrace_a-syscall.o `test -f 'syscall.c' || echo './'`syscall.c
> syscall.c:670:65: error: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
>         int res = raw(tcp) ? printargs(tcp) : tcp_sysent(tcp)->sys_func(tcp);
>                                                                        ^
> syscall.c:815:39: error: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
>                         sys_res = tcp_sysent(tcp)->sys_func(tcp);
>                                                            ^
> 2 errors generated.