### PR TITLE
Add missing permission `security-events` for Differential ShellCheck GA

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -15,6 +15,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    permissions:
+      security-events: write
+
     steps:
       - name: Repository checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Differential ShellCheck requires permission `security-events: write` to upload the SARIF file to GitHub successfully.

This permission might be optional for some repositories since they allow all permissions for all workflows in settings. But I wouldn't advise this setting since the best security practice is to allow only a minimal set of required permissions.

Failed to upload SARIF - [logs](https://github.com/strace/strace/actions/runs/3980140518/jobs/6823022346#step:4:31)