### PR TITLE
tests: remove getpid and getppid from check_PROGRAMS

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -152,9 +152,7 @@ check_PROGRAMS = $(PURE_EXECUTABLES) \
 	fsync-y \
 	get_process_reaper \
 	getpgrp--pidns-translation	\
-	getpid	\
 	getpid--pidns-translation	\
-	getppid	\
 	getsid--pidns-translation \
 	gettid \
 	gettid--pidns-translation \


### PR DESCRIPTION
getpid and getppid are already listed in $(PURE_EXECUTABLES). Remove the duplicate entries.