### PR TITLE
mips: fix raw_syscall_0

### DIFF
--- a/src/linux/mips/raw_syscall.h
+++ b/src/linux/mips/raw_syscall.h
@@ -12,6 +12,18 @@
 
 # include "kernel_types.h"
 
+#if __mips_isa_rev >= 6
+#define SYSCALL_CLOBBERLIST \
+	"memory", "$1", "$3", "$8", "$9", \
+	"$10", "$11", "$12", "$13", "$14", "$15", \
+	"$24", "$25"
+#else
+#define SYSCALL_CLOBBERLIST \
+	"memory", "hi", "lo", "$1", "$3", "$8", "$9", \
+	"$10", "$11", "$12", "$13", "$14", "$15", \
+	"$24", "$25"
+#endif
+
 static inline kernel_ulong_t
 raw_syscall_0(const kernel_ulong_t nr, kernel_ulong_t *err)
 {
@@ -24,9 +36,7 @@ raw_syscall_0(const kernel_ulong_t nr, kernel_ulong_t *err)
 			     ".set reorder"
 			     : "=r"(v0), "=r"(a3)
 			     : "r"(s0)
-			     : "memory", "hi", "lo", "$1", "$3", "$8", "$9",
-			       "$10", "$11", "$12", "$13", "$14", "$15",
-			       "$24", "$25");
+			     : SYSCALL_CLOBBERLIST);
 	*err = a3;
 	return v0;
 }


### PR DESCRIPTION
Some of the tests use a custom function (raw_syscall_0) for syscall invocation.

The implementation for mips was flawed: it unconditionally clobbered "hi" and "lo", which is not valid for MIPS R6, because these targets lack those registers w/o DSP extension.

GCC 10+ refuses to compile such constructs: [1], [2].

Fix the syscall invocation implementation for mips.

[1] https://gcc.gnu.org/git/?p=gcc.git&a=commit;h=0a59215131c02dee4c8829f93d1ee678647614da
[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91233

* src/linux/mips/raw_syscall.h: Add SYSCALL_CLOBBERLIST.
(raw_syscall_0): Use it.