### PR TITLE
Identify netlink by proto when msghdr.msg_name is not set

### DIFF
--- a/src/msghdr.c
+++ b/src/msghdr.c
@@ -397,10 +397,13 @@ print_struct_msghdr(struct tcb *tcp, const struct msghdr *msg,
 	tprints_field_name("msg_name");
 	const int family =
 		decode_sockaddr(tcp, ptr_to_kulong(msg->msg_name), msg_namelen);
-	const print_obj_by_addr_size_fn print_func =
-		(family == AF_NETLINK) ? iov_decode_netlink : iov_decode_str;
 	/* Assume that the descriptor is the 1st syscall argument. */
 	int fd = tcp->u_arg[0];
+	const enum sock_proto proto =
+		(family == -1) ? getfdproto(tcp, fd) : SOCK_PROTO_UNKNOWN;
+	const print_obj_by_addr_size_fn print_func =
+		(family == AF_NETLINK || proto == SOCK_PROTO_NETLINK)
+		? iov_decode_netlink : iov_decode_str;
 
 	tprint_struct_next();
 	tprints_field_name("msg_namelen");

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -577,7 +577,7 @@ net-tpacket_stats-success -einject=getsockopt:retval=42 -etrace=getsockopt
 net-yy-inet6	+net-yy-inet.test
 netlink_audit	+netlink_sock_diag.test
 netlink_crypto	+netlink_sock_diag.test
-netlink_generic	+netlink_sock_diag.test
+netlink_generic	+netlink_sock_diag.test -e trace=sendto,sendmsg
 netlink_kobject_uevent	+netlink_sock_diag.test
 netlink_netfilter	+netlink_sock_diag.test
 netlink_protocol	+netlink_sock_diag.test

--- a/tests/netlink_generic.c
+++ b/tests/netlink_generic.c
@@ -47,6 +47,47 @@ test_nlmsg_type(const int fd)
 	       (unsigned int) sizeof(req), sprintrc(rc));
 }
 
+static void
+test_sendmsg_nlmsg_type(const int fd)
+{
+	/*
+	 * Though GENL_ID_CTRL number is statically fixed in this test case,
+	 * strace does not have a builtin knowledge that the corresponding
+	 * string is "nlctrl".
+	 */
+	long rc;
+	struct {
+		const struct nlmsghdr nlh;
+		struct genlmsghdr gnlh;
+	} req = {
+		.nlh = {
+			.nlmsg_len = sizeof(req),
+			.nlmsg_type = GENL_ID_CTRL,
+			.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST
+		},
+		.gnlh = {
+			.cmd = CTRL_CMD_GETFAMILY
+		}
+	};
+
+        struct iovec iov[1] = {
+		{ .iov_base = &req, .iov_len = sizeof(req) }
+        };
+        struct msghdr msg = {
+		.msg_iov = iov,
+		.msg_iovlen = 1
+        };
+
+        rc = sendmsg(fd, &msg, MSG_DONTWAIT);
+        printf("sendmsg(%d, {msg_name=NULL, msg_namelen=0"
+	       ", msg_iov=[{iov_base=[{nlmsg_len=%u, nlmsg_type=nlctrl"
+	       ", nlmsg_flags=NLM_F_REQUEST|0x300, nlmsg_seq=0, nlmsg_pid=0}"
+	       ", \"\\x03\\x00\\x00\\x00\"], iov_len=%u}], msg_iovlen=1"
+	       ", msg_controllen=0, msg_flags=0}, MSG_DONTWAIT) = %s\n",
+	       fd, req.nlh.nlmsg_len, (unsigned int) iov[0].iov_len,
+	       sprintrc(rc));
+}
+
 int main(void)
 {
 	skip_if_unavailable("/proc/self/fd/");
@@ -54,6 +95,7 @@ int main(void)
 	int fd = create_nl_socket(NETLINK_GENERIC);
 
 	test_nlmsg_type(fd);
+	test_sendmsg_nlmsg_type(fd);
 
 	printf("+++ exited with 0 +++\n");
 


### PR DESCRIPTION
Some clients, e.g. ovs-dpctl, use sendmsg with a connected socket so the address family cannot be identified by msg_name. Look up the fd proto when msg_name is NULL.