### PR TITLE
tests: do not use libc definitions for timespec/timeval

### DIFF
--- a/tests/aio.c
+++ b/tests/aio.c
@@ -10,6 +10,7 @@
 
 #include "tests.h"
 #include "scno.h"
+#include "kernel_old_timespec.h"
 
 #ifdef __NR_io_getevents
 # include <fcntl.h>
@@ -184,7 +185,7 @@ main(void)
 	const unsigned long lnr = (unsigned long) (0xdeadbeef00000000ULL | nr);
 
 	const struct io_event *ev = tail_alloc(nr * sizeof(struct io_event));
-	TAIL_ALLOC_OBJECT_CONST_PTR(struct timespec, ts);
+	TAIL_ALLOC_OBJECT_CONST_PTR(kernel_old_timespec_t, ts);
 
 	(void) close(0);
 	if (open("/dev/zero", O_RDONLY))

--- a/tests/aio_pgetevents.c
+++ b/tests/aio_pgetevents.c
@@ -11,6 +11,7 @@
 #include "tests.h"
 #include <unistd.h>
 #include "scno.h"
+#include "kernel_old_timespec.h"
 
 #ifdef __NR_io_pgetevents
 
@@ -92,7 +93,7 @@ main(void)
 	const unsigned int nr = ARRAY_SIZE(proto_cb);
 
 	const struct io_event *ev = tail_alloc(nr * sizeof(struct io_event));
-	TAIL_ALLOC_OBJECT_CONST_PTR(struct timespec, ts);
+	TAIL_ALLOC_OBJECT_CONST_PTR(kernel_old_timespec_t, ts);
 	TAIL_ALLOC_OBJECT_CONST_PTR(struct __aio_sigset, ss);
 	TAIL_ALLOC_OBJECT_CONST_PTR(sigset_t, sigs);
 

--- a/tests/clock_nanosleep.c
+++ b/tests/clock_nanosleep.c
@@ -10,6 +10,7 @@
 
 #include "tests.h"
 #include "scno.h"
+#include "kernel_old_timespec.h"
 
 #ifdef __NR_clock_nanosleep
 
@@ -30,7 +31,7 @@ int
 main(void)
 {
 	struct {
-		struct timespec ts;
+		kernel_old_timespec_t ts;
 		uint32_t pad[2];
 	} req = {
 		.ts.tv_nsec = 0xc0de1,

--- a/tests/futex.c
+++ b/tests/futex.c
@@ -9,6 +9,7 @@
 #include "tests.h"
 
 #include "scno.h"
+#include "kernel_old_timespec.h"
 
 #ifdef __NR_futex
 
@@ -161,7 +162,7 @@ main(int argc, char *argv[])
 	uaddr[0] = 0x1deadead;
 	uaddr2[0] = 0xbadf00d;
 
-	TAIL_ALLOC_OBJECT_CONST_PTR(struct timespec, tmout);
+	TAIL_ALLOC_OBJECT_CONST_PTR(kernel_old_timespec_t, tmout);
 	tmout->tv_sec = 123;
 	tmout->tv_nsec = 0xbadc0de;
 

--- a/tests/futimesat.c
+++ b/tests/futimesat.c
@@ -10,6 +10,7 @@
 
 #include "tests.h"
 #include "scno.h"
+#include "kernel_timeval.h"
 
 #ifdef __NR_futimesat
 
@@ -19,7 +20,7 @@
 # include <unistd.h>
 
 static void
-print_tv(const struct timeval *tv)
+print_tv(const kernel_old_timeval_t *tv)
 {
 	printf("{tv_sec=%lld, tv_usec=%llu}",
 	       (long long) tv->tv_sec,
@@ -52,7 +53,7 @@ main(void)
 
 	char *const fname = tail_memdup(proto_fname, sizeof(proto_fname));
 	const kernel_ulong_t kfname = (uintptr_t) fname;
-	struct timeval *const tv = tail_alloc(sizeof(*tv) * 2);
+	kernel_old_timeval_t *const tv = tail_alloc(sizeof(*tv) * 2);
 
 	(void) close(0);
 

--- a/tests/libmmsg.c
+++ b/tests/libmmsg.c
@@ -25,7 +25,7 @@
 int
 recv_mmsg(const int fd, struct mmsghdr *const vec,
 	  const unsigned int vlen, const unsigned int flags,
-	  struct timespec *const timeout)
+	  kernel_old_timespec_t *const timeout)
 {
 	int rc = socketcall(__NR_recvmmsg, SC_recvmmsg,
 			    fd, (long) vec, vlen, flags, (long) timeout);

--- a/tests/mmsg-silent.c
+++ b/tests/mmsg-silent.c
@@ -33,7 +33,7 @@ main(void)
 		perror_msg_and_skip("sendmmsg");
 	printf("sendmmsg(%d, %p, 1, MSG_DONTWAIT) = %d\n", fds[1], &mh, rc);
 
-	struct timespec t = { .tv_sec = 0, .tv_nsec = 12345678 };
+	kernel_old_timespec_t t = { .tv_sec = 0, .tv_nsec = 12345678 };
 	rc = recv_mmsg(fds[0], &mh, 1, MSG_DONTWAIT, &t);
 	printf("recvmmsg(%d, %p, 1, MSG_DONTWAIT, %p) = %d\n",
 	       fds[0], &mh, &t, rc);

--- a/tests/ppoll.c
+++ b/tests/ppoll.c
@@ -10,6 +10,7 @@
 
 #include "tests.h"
 #include "scno.h"
+#include "kernel_old_timespec.h"
 
 #ifdef __NR_ppoll
 
@@ -72,7 +73,7 @@ main(void)
 	static const char *const USR2_CHLD_str =
 		(SIGUSR2 < SIGCHLD) ? "USR2 CHLD" : "CHLD USR2";
 	void *const efault = tail_alloc(1024) + 1024;
-	TAIL_ALLOC_OBJECT_CONST_PTR(struct timespec, ts);
+	TAIL_ALLOC_OBJECT_CONST_PTR(kernel_old_timespec_t, ts);
 	const unsigned int sigset_size = get_sigset_size();
 	void *const sigmask = tail_alloc(sigset_size);
 	struct pollfd *fds;

--- a/tests/recvmmsg-timeout.c
+++ b/tests/recvmmsg-timeout.c
@@ -9,6 +9,7 @@
  */
 
 #include "tests.h"
+#include "kernel_old_timespec.h"
 #include <stdio.h>
 
 #include "msghdr.h"
@@ -31,7 +32,7 @@ main(void)
 			.msg_iovlen = 1
 		}
 	};
-	TAIL_ALLOC_OBJECT_CONST_PTR(struct timespec, ts);
+	TAIL_ALLOC_OBJECT_CONST_PTR(kernel_old_timespec_t, ts);
 	ts->tv_sec = 0;
 	ts->tv_nsec = 12345678;
 

--- a/tests/rt_sigtimedwait.c
+++ b/tests/rt_sigtimedwait.c
@@ -10,6 +10,7 @@
 
 #include "tests.h"
 #include "scno.h"
+#include "kernel_old_timespec.h"
 
 #ifdef __NR_rt_sigtimedwait
 
@@ -23,14 +24,14 @@
 
 static long
 k_sigtimedwait(const sigset_t *const set, siginfo_t *const info,
-	       const struct timespec *const timeout, const unsigned long size)
+	       const kernel_old_timespec_t *const timeout, const unsigned long size)
 {
 	return syscall(__NR_rt_sigtimedwait, set, info, timeout, size);
 }
 
 static void
 iterate(const char *const text, const void *set,
-	const struct timespec *const timeout, unsigned int size)
+	const kernel_old_timespec_t *const timeout, unsigned int size)
 {
 	for (;;) {
 		assert(k_sigtimedwait(set, NULL, timeout, size) == -1);
@@ -70,7 +71,7 @@ main(void)
 	tprintf("%s", "");
 
 	TAIL_ALLOC_OBJECT_CONST_PTR(siginfo_t, info);
-	TAIL_ALLOC_OBJECT_CONST_PTR(struct timespec, timeout);
+	TAIL_ALLOC_OBJECT_CONST_PTR(kernel_old_timespec_t, timeout);
 	timeout->tv_sec = 0;
 	timeout->tv_nsec = 42;
 

--- a/tests/sched_rr_get_interval.c
+++ b/tests/sched_rr_get_interval.c
@@ -7,6 +7,8 @@
 
 #include "tests.h"
 #include "scno.h"
+#include "kernel_old_timespec.h"
+
 
 #ifdef __NR_sched_rr_get_interval
 
@@ -18,7 +20,7 @@
 int
 main(void)
 {
-	TAIL_ALLOC_OBJECT_CONST_PTR(struct timespec, tp);
+	TAIL_ALLOC_OBJECT_CONST_PTR(kernel_old_timespec_t, tp);
 	long rc;
 
 	rc = syscall(__NR_sched_rr_get_interval, 0, NULL);

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -27,6 +27,7 @@
 # include <stdint.h>
 # include <sys/types.h>
 # include "kernel_types.h"
+# include "kernel_old_timespec.h"
 # include "gcc_compat.h"
 # include "macros.h"
 
@@ -407,8 +408,7 @@ void test_status_chdir(const char *dir, bool print_success, bool print_fail);
 
 /* Wrappers for recvmmsg and sendmmsg syscalls. */
 struct mmsghdr;
-struct timespec;
-int recv_mmsg(int, struct mmsghdr *, unsigned int, unsigned int, struct timespec *);
+int recv_mmsg(int, struct mmsghdr *, unsigned int, unsigned int, kernel_old_timespec_t *);
 int send_mmsg(int, struct mmsghdr *, unsigned int, unsigned int);
 
 /* Create a netlink socket. */

--- a/tests/utimensat.c
+++ b/tests/utimensat.c
@@ -16,6 +16,8 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include "scno.h"
+#include "kernel_old_timespec.h"
+
 
 #if defined __NR_utimensat && defined UTIME_NOW && defined UTIME_OMIT
 
@@ -60,7 +62,7 @@
 # endif
 
 static void
-print_ts(const struct timespec *ts)
+print_ts(const kernel_old_timespec_t *ts)
 {
 	printf("{tv_sec=%lld, tv_nsec=%llu}", (long long) ts->tv_sec,
 		zero_extend_signed_to_ull(ts->tv_nsec));
@@ -93,7 +95,7 @@ main(void)
 
 	char *const fname = tail_memdup(proto_fname, sizeof(proto_fname));
 	const kernel_ulong_t kfname = (uintptr_t) fname;
-	struct timespec *const ts = tail_alloc(sizeof(*ts) * 2);
+	kernel_old_timespec_t *const ts = tail_alloc(sizeof(*ts) * 2);
 
 	(void) close(0);
 

--- a/tests/utimes.c
+++ b/tests/utimes.c
@@ -10,12 +10,13 @@
 
 #include "tests.h"
 #include "scno.h"
+#include "kernel_timeval.h"
 
 #ifdef __NR_utimes
 
 # define TEST_SYSCALL_NR	__NR_utimes
 # define TEST_SYSCALL_STR	"utimes"
-# define TEST_STRUCT		struct timeval
+# define TEST_STRUCT		kernel_old_timeval_t
 # include "xutimes.c"
 
 #else

--- a/tests/xettimeofday.c
+++ b/tests/xettimeofday.c
@@ -8,6 +8,7 @@
 
 #include "tests.h"
 #include "scno.h"
+#include "kernel_timeval.h"
 
 #ifdef __NR_gettimeofday
 
@@ -21,7 +22,7 @@
 int
 main(void)
 {
-	TAIL_ALLOC_OBJECT_CONST_PTR(struct timeval, tv);
+	TAIL_ALLOC_OBJECT_CONST_PTR(kernel_old_timeval_t, tv);
 	TAIL_ALLOC_OBJECT_CONST_PTR(struct timezone, tz);
 
 	if (syscall(__NR_gettimeofday, tv, NULL))

--- a/tests/xselect.c
+++ b/tests/xselect.c
@@ -20,6 +20,8 @@
 #include <unistd.h>
 #include <sys/select.h>
 
+#include "kernel_timeval.h"
+
 static const char *errstr;
 
 static long
@@ -89,8 +91,8 @@ main(void)
 		error_msg_and_fail("nfds[%d] > smallset_size[%d]\n",
 				   nfds, smallset_size);
 
-	struct timeval tv_in = { 0, 123 };
-	struct timeval *const tv = tail_memdup(&tv_in, sizeof(tv_in));
+	kernel_old_timeval_t tv_in = { 0, 123 };
+	kernel_old_timeval_t *const tv = tail_memdup(&tv_in, sizeof(tv_in));
 	const uintptr_t a_tv = (uintptr_t) tv;
 
 	TAIL_ALLOC_OBJECT_VAR_PTR(kernel_ulong_t, l_rs);


### PR DESCRIPTION
libc does not guarantee that they match syscall structures, and indeed, they don't if components are built against glibc with -D_TIME_BITS=64 on 32 bit platforms (to avoid collapse in 2038).

Resolves: https://github.com/strace/strace/issues/250