### PR TITLE
tests/clock_nanosleep.c: avoid use of CLOCK_ABSTIME on systems with 32 bit time_t.

### DIFF
--- a/tests/clock_nanosleep.c
+++ b/tests/clock_nanosleep.c
@@ -115,6 +115,12 @@ main(void)
 	       (long long) req.ts.tv_sec,
 	       zero_extend_signed_to_ull(req.ts.tv_nsec));
 
+        /* If time_t is 32 bit, it is no longer possible to represent post-2038 times
+         * via the clock_nanosleep syscall so we should simply stop and exit.
+         * It is not a failure. */
+	if (sizeof(req.ts.tv_sec) < 8)
+		goto exit;
+
 	++req.ts.tv_sec;
 	rem.ts.tv_sec = 0xc0de4;
 	rem.ts.tv_nsec = 0xc0de5;
@@ -127,6 +133,7 @@ main(void)
 	       zero_extend_signed_to_ull(req.ts.tv_nsec), &rem.ts);
 	puts("--- SIGALRM {si_signo=SIGALRM, si_code=SI_KERNEL} ---");
 
+exit:
 	puts("+++ exited with 0 +++");
 	return 0;
 }


### PR DESCRIPTION
This does break (syscall returning -EINVAL) if system date is set to post-2038.