### PR TITLE
add --stacktrace-frames-limit support for unwinding

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@ Noteworthy changes in release ?.? (????-??-??)
 ==============================================
 
 * Improvements
+  * Implemented --stack-trace-frame-limit=N option for configuring the limit
+    of the number of printed backtrace frames.
   * Updated decoding of landlock_create_ruleset and landlock_add_rule syscalls.
   * Updated decoding of SMC_DIAG_DMBINFO netlink attribute.
   * Updated decoding of UBI_IOCATT ioctl command.

--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -58,7 +58,7 @@ strace \- trace system calls and signals
 .OP \-X format
 .OP \-\-seccomp\-bpf
 .if '@ENABLE_STACKTRACE_FALSE@'#' .OP \-\-stack\-trace\-frame\-limit\fR=\fIlimit\fR
-.OP \-\-syscall\-limit limit
+.OP \-\-syscall\-limit=\fIlimit\fR
 .if '@ENABLE_SECONTEXT_FALSE@'#' .OP \-\-secontext\fR[=\fIformat\fR]
 .OP \-\-tips\fR[=\fIformat\fR]
 .BR "" {
@@ -82,7 +82,7 @@ strace \- trace system calls and signals
 .OP \-S sortby
 .OP \-U columns
 .OP \-\-seccomp\-bpf
-.OP \-\-syscall\-limit limit
+.OP \-\-syscall\-limit=\fIlimit\fR
 .OP \-\-tips\fR[=\fIformat\fR]
 .BR "" {
 .OR \-p pid
@@ -1001,25 +1001,25 @@ Print the syscall number.
 .if '@ENABLE_STACKTRACE_FALSE@'#' .TP
 .if '@ENABLE_STACKTRACE_FALSE@'#' .B \-k
 .if '@ENABLE_STACKTRACE_FALSE@'#' .TQ
-.if '@ENABLE_STACKTRACE_FALSE@'#' .B \-\-stack\-traces [= symbol ]
+.if '@ENABLE_STACKTRACE_FALSE@'#' .BR \-\-stack\-traces [= symbol ]
 .if '@ENABLE_STACKTRACE_FALSE@'#' Print the execution stack trace of the traced
 .if '@ENABLE_STACKTRACE_FALSE@'#' processes after each system call.
 .if '@USE_LIBDW_FALSE@'#' .TP
 .if '@USE_LIBDW_FALSE@'#' .B \-kk
 .if '@USE_LIBDW_FALSE@'#' .TQ
-.if '@USE_LIBDW_FALSE@'#' .B \-\-stack\-traces [= source ]
+.if '@USE_LIBDW_FALSE@'#' .BR \-\-stack\-traces = source
 .if '@USE_LIBDW_FALSE@'#' Print the execution stack trace and source code information of the traced
 .if '@USE_LIBDW_FALSE@'#' processes after each system call. This option expects the target program is compiled
 .if '@USE_LIBDW_FALSE@'#' with appropriate debug options: "\-g" (gcc), or "\-g \-gdwarf-aranges" (clang).
 .if '@ENABLE_STACKTRACE_FALSE@'#' .TP
-.if '@ENABLE_STACKTRACE_FALSE@'#' .B \-\-stack\-trace\-frame\-limit = limit
+.if '@ENABLE_STACKTRACE_FALSE@'#' .BR \-\-stack\-trace\-frame\-limit = \fIlimit\fR
 .if '@ENABLE_STACKTRACE_FALSE@'#' Print no more than this amount of stack trace frames
 .if '@ENABLE_STACKTRACE_FALSE@'#' when backtracing a system call (the default is 256).
 .if '@ENABLE_STACKTRACE_FALSE@'#' Use this option with
 .if '@ENABLE_STACKTRACE_FALSE@'#' .B \-\-stack\-traces
 .if '@ENABLE_STACKTRACE_FALSE@'#' (or
-.if '@ENABLE_STACKTRACE_FALSE@'#' .B \-k
-.if '@ENABLE_STACKTRACE_FALSE@'#' ) options.
+.if '@ENABLE_STACKTRACE_FALSE@'#' .BR \-k )
+.if '@ENABLE_STACKTRACE_FALSE@'#' options.
 .TP
 .BI "\-o " filename
 .TQ

--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -57,6 +57,7 @@ strace \- trace system calls and signals
 .OP \-U columns
 .OP \-X format
 .OP \-\-seccomp\-bpf
+.if '@ENABLE_STACKTRACE_FALSE@'#' .OP \-\-stack\-trace\-frame\-limit\fR=\fIlimit\fR
 .OP \-\-syscall\-limit limit
 .if '@ENABLE_SECONTEXT_FALSE@'#' .OP \-\-secontext\fR[=\fIformat\fR]
 .OP \-\-tips\fR[=\fIformat\fR]
@@ -1010,6 +1011,15 @@ Print the syscall number.
 .if '@USE_LIBDW_FALSE@'#' Print the execution stack trace and source code information of the traced
 .if '@USE_LIBDW_FALSE@'#' processes after each system call. This option expects the target program is compiled
 .if '@USE_LIBDW_FALSE@'#' with appropriate debug options: "\-g" (gcc), or "\-g \-gdwarf-aranges" (clang).
+.if '@ENABLE_STACKTRACE_FALSE@'#' .TP
+.if '@ENABLE_STACKTRACE_FALSE@'#' .B \-\-stack\-trace\-frame\-limit = limit
+.if '@ENABLE_STACKTRACE_FALSE@'#' Print no more than this amount of stack trace frames
+.if '@ENABLE_STACKTRACE_FALSE@'#' when backtracing a system call (the default is 256).
+.if '@ENABLE_STACKTRACE_FALSE@'#' Use this option with
+.if '@ENABLE_STACKTRACE_FALSE@'#' .B \-\-stack\-traces
+.if '@ENABLE_STACKTRACE_FALSE@'#' (or
+.if '@ENABLE_STACKTRACE_FALSE@'#' .B \-k
+.if '@ENABLE_STACKTRACE_FALSE@'#' ) options.
 .TP
 .BI "\-o " filename
 .TQ

--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -1015,11 +1015,11 @@ Print the syscall number.
 .if '@ENABLE_STACKTRACE_FALSE@'#' .BR \-\-stack\-trace\-frame\-limit = \fIlimit\fR
 .if '@ENABLE_STACKTRACE_FALSE@'#' Print no more than this amount of stack trace frames
 .if '@ENABLE_STACKTRACE_FALSE@'#' when backtracing a system call (the default is 256).
-.if '@ENABLE_STACKTRACE_FALSE@'#' Use this option with
+.if '@ENABLE_STACKTRACE_FALSE@'#' Use this option with the
 .if '@ENABLE_STACKTRACE_FALSE@'#' .B \-\-stack\-traces
 .if '@ENABLE_STACKTRACE_FALSE@'#' (or
 .if '@ENABLE_STACKTRACE_FALSE@'#' .BR \-k )
-.if '@ENABLE_STACKTRACE_FALSE@'#' options.
+.if '@ENABLE_STACKTRACE_FALSE@'#' option.
 .TP
 .BI "\-o " filename
 .TQ

--- a/src/defs.h
+++ b/src/defs.h
@@ -72,6 +72,10 @@ extern char *stpcpy(char *dst, const char *src);
 # ifndef DEFAULT_ACOLUMN
 #  define DEFAULT_ACOLUMN	40	/* default alignment column for results */
 # endif
+# ifndef DEFAULT_STACK_TRACE_FRAME_LIMIT
+/* Default limit for the amount of frames obtained during syscall backtrace.  */
+#  define DEFAULT_STACK_TRACE_FRAME_LIMIT 256
+# endif
 /*
  * Maximum number of args to a syscall.
  *
@@ -1566,7 +1570,7 @@ extern void print_ticks_d(int64_t val, long freq, unsigned int precision);
 extern void print_clock_t(uint64_t val);
 
 # ifdef ENABLE_STACKTRACE
-extern void unwind_init(bool);
+extern void unwind_init(bool, int);
 extern void unwind_tcb_init(struct tcb *);
 extern void unwind_tcb_fin(struct tcb *);
 extern void unwind_tcb_print(struct tcb *);

--- a/src/strace.c
+++ b/src/strace.c
@@ -407,6 +407,11 @@ Output format:\n\
                  obtain stack trace and source info between each syscall\n\
 "
 #endif
+"\
+  --stack-trace-frame-limit=limit\n\
+                 obtain no more than this amount of frames\n\
+                 when backtracing a syscall (default %d)\n\
+"
 #endif
 "\
   -n, --syscall-number\n\
@@ -515,7 +520,11 @@ Miscellaneous:\n\
 /* ancient, no one should use it
 -F -- attempt to follow vforks (deprecated, use -f)\n\
  */
-, DEFAULT_ACOLUMN, DEFAULT_STRLEN, DEFAULT_SORTBY);
+, DEFAULT_ACOLUMN,
+#ifdef ENABLE_STACKTRACE
+ DEFAULT_STACK_TRACE_FRAME_LIMIT,
+#endif
+ DEFAULT_STRLEN, DEFAULT_SORTBY);
 	exit(0);
 
 #undef K_OPT
@@ -2243,6 +2252,9 @@ init(int argc, char *argv[])
 	bool columns_set = false;
 	bool sortby_set = false;
 	bool opt_kill_on_exit = false;
+#ifdef ENABLE_STACKTRACE
+	int stack_trace_frame_limit = DEFAULT_STACK_TRACE_FRAME_LIMIT;
+#endif
 
 	/*
 	 * We can initialise global_path_set only after tracing backend
@@ -2311,6 +2323,7 @@ init(int argc, char *argv[])
 		GETOPT_TS,
 		GETOPT_TIPS,
 		GETOPT_ARGV0,
+		GETOPT_STACK_TRACE_FRAME_LIMIT,
 
 		GETOPT_QUAL_TRACE,
 		GETOPT_QUAL_TRACE_FD,
@@ -2348,6 +2361,7 @@ init(int argc, char *argv[])
 		{ "interruptible",	required_argument, 0, 'I' },
 		{ "kill-on-exit",	no_argument,	   0, GETOPT_KILL_ON_EXIT },
 		{ "stack-traces" ,	optional_argument, 0, GETOPT_STACK },
+		{ "stack-trace-frame-limit", required_argument, 0, GETOPT_STACK_TRACE_FRAME_LIMIT },
 		{ "syscall-limit",	required_argument, 0, GETOPT_SYSCALL_LIMIT },
 		{ "syscall-number",	no_argument,	   0, 'n' },
 		{ "output",		required_argument, 0, 'o' },
@@ -2530,6 +2544,19 @@ init(int argc, char *argv[])
 					  "option) are not supported by this "
 					  "build of strace");
 #endif /* ENABLE_STACKTRACE */
+			break;
+		case GETOPT_STACK_TRACE_FRAME_LIMIT:
+			i = string_to_uint(optarg);
+			if (i <= 0 || (unsigned int) i > -1U / 4)
+				error_opt_arg(c, lopt, optarg);
+#ifdef ENABLE_STACKTRACE
+			stack_trace_frame_limit = i;
+#else
+			error_msg_and_die("Stack traces "
+					  "(--stack-trace-frame-limit "
+					  "option) are not supported "
+					  "by this build of strace");
+#endif
 			break;
 		case GETOPT_KILL_ON_EXIT:
 			opt_kill_on_exit = true;
@@ -2919,7 +2946,8 @@ init(int argc, char *argv[])
 
 #ifdef ENABLE_STACKTRACE
 	if (stack_trace_mode)
-		unwind_init(stack_trace_mode == STACK_TRACE_WITH_SRCINFO);
+		unwind_init(stack_trace_mode == STACK_TRACE_WITH_SRCINFO,
+			    stack_trace_frame_limit);
 #endif
 
 	/* See if they want to run as another user. */

--- a/src/strace.c
+++ b/src/strace.c
@@ -2253,7 +2253,7 @@ init(int argc, char *argv[])
 	bool sortby_set = false;
 	bool opt_kill_on_exit = false;
 #ifdef ENABLE_STACKTRACE
-	int stack_trace_frame_limit = DEFAULT_STACK_TRACE_FRAME_LIMIT;
+	int stack_trace_frame_limit = 0;
 #endif
 
 	/*
@@ -2945,9 +2945,16 @@ init(int argc, char *argv[])
 	set_sighandler(SIGCHLD, SIG_DFL, &params_for_tracee.child_sa);
 
 #ifdef ENABLE_STACKTRACE
-	if (stack_trace_mode)
+	if (stack_trace_mode) {
+		if (stack_trace_frame_limit == 0)
+			stack_trace_frame_limit =
+				DEFAULT_STACK_TRACE_FRAME_LIMIT;
 		unwind_init(stack_trace_mode == STACK_TRACE_WITH_SRCINFO,
 			    stack_trace_frame_limit);
+	} else if (stack_trace_frame_limit != 0) {
+		error_msg("--stack-trace-frame-limit has no effect "
+			  "without -k/--stack-traces");
+	}
 #endif
 
 	/* See if they want to run as another user. */

--- a/src/unwind-libdw.c
+++ b/src/unwind-libdw.c
@@ -235,7 +235,7 @@ frame_callback(Dwfl_Frame *state, void *arg)
 	}
 
 	/* Max number of frames to print reached? */
-	if (user_data->stack_depth-- == 0)
+	if (--user_data->stack_depth == 0)
 		return DWARF_CB_ABORT;
 
 	return DWARF_CB_OK;

--- a/src/unwind-libdw.c
+++ b/src/unwind-libdw.c
@@ -52,6 +52,7 @@ struct ctx {
 static unsigned long long mapping_generation = 1;
 static unsigned long long uwcache_clock;
 static bool with_srcinfo;
+static int stack_trace_limit;
 
 static void
 update_mapping_generation(struct tcb *tcp, void *unused)
@@ -60,9 +61,10 @@ update_mapping_generation(struct tcb *tcp, void *unused)
 }
 
 static void
-init(bool with_srcinfo_)
+init(bool with_srcinfo_, int stack_trace_limit_)
 {
 	with_srcinfo = with_srcinfo_;
+	stack_trace_limit = stack_trace_limit_;
 	mmap_notify_register_client(update_mapping_generation, NULL);
 }
 
@@ -255,7 +257,7 @@ tcb_walk(struct tcb *tcp,
 		.call_action = call_action,
 		.error_action = error_action,
 		.data = data,
-		.stack_depth = 256,
+		.stack_depth = stack_trace_limit,
 		.ctx = ctx,
 	};
 

--- a/src/unwind.c
+++ b/src/unwind.c
@@ -37,10 +37,10 @@ static void queue_print(struct unwind_queue_t *queue);
 static const char asprintf_error_str[] = "???";
 
 void
-unwind_init(bool with_srcinfo)
+unwind_init(bool with_srcinfo, int stack_trace_limit)
 {
 	if (unwinder.init)
-		unwinder.init(with_srcinfo);
+		unwinder.init(with_srcinfo, stack_trace_limit);
 }
 
 void

--- a/src/unwind.h
+++ b/src/unwind.h
@@ -37,8 +37,7 @@ typedef void (*unwind_error_action_fn)(void *data,
 struct unwind_unwinder_t {
 	const char *name;
 
-	/* Initialize the unwinder. */
-	void   (*init)(bool);
+	void   (*init)(bool, int);
 
 	/* Make/destroy the context data attached to tcb. */
 	void * (*tcb_init)(struct tcb *);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -501,7 +501,7 @@ trie_test_LDADD = $(LDADD) $(CODE_COVERAGE_LIBS)
 include gen_tests.am
 
 if ENABLE_STACKTRACE
-STACKTRACE_TESTS = strace-k.test strace-k-p.test
+STACKTRACE_TESTS = strace-k.test strace-k-p.test strace-k-with-depth-limit.test
 if USE_LIBDW
 STACKTRACE_TESTS += strace-kk.test strace-kk-p.test
 endif
@@ -708,6 +708,7 @@ check_SCRIPTS = \
 	scno_tampering.sh \
 	strace-k-demangle.test \
 	strace-k-p.test \
+	strace-k-with-depth-limit.test \
 	strace-k.test \
 	strace-kk-p.test \
 	strace-kk.test \
@@ -766,6 +767,7 @@ check_DATA = \
 	strace-ff.expected \
 	strace-k-demangle.expected \
 	strace-k-p.expected \
+	strace-k-with-depth-limit.expected \
 	strace-k.expected \
 	strace-kk-p.expected \
 	strace-kk.expected \

--- a/tests/options-syntax.test
+++ b/tests/options-syntax.test
@@ -417,11 +417,15 @@ fi
 check_e_using_grep 'ptrace_setoptions = 0x[[:xdigit:]]+' -d /
 check_e_using_grep 'ptrace_setoptions = 0x[[:xdigit:]]+' --debug /
 
+check_h "invalid --stack-trace-frame-limit argument: '1073741824'" --stack-trace-frame-limit 1073741824
+check_h "invalid --stack-trace-frame-limit argument: '0'" --stack-trace-frame-limit=0
 if [ -z "$compiled_with_stacktrace" ]; then
 	check_e "Stack traces (-k/--stack-traces option) are not supported by this build of strace" -k
 	check_e "Stack traces (-k/--stack-traces option) are not supported by this build of strace" --stack-traces
 	check_e "Stack traces (-k/--stack-traces option) are not supported by this build of strace" --stack-traces=symbol
 	check_e "Stack traces (-k/--stack-traces option) are not supported by this build of strace" --stack-traces=source
+	check_e "Stack traces (--stack-trace-frame-limit option) are not supported by this build of strace" \
+		--stack-trace-frame-limit=1
 else
 	if [ -n "$compiled_with_libunwind" ]; then
 		check_e "Stack traces with source line information (-kk/--stack-traces=source option) are not supported by this build of strace" -kk

--- a/tests/options-syntax.test
+++ b/tests/options-syntax.test
@@ -427,6 +427,8 @@ if [ -z "$compiled_with_stacktrace" ]; then
 	check_e "Stack traces (--stack-trace-frame-limit option) are not supported by this build of strace" \
 		--stack-trace-frame-limit=1
 else
+	check_e "--stack-trace-frame-limit has no effect without -k/--stack-traces
+$STRACE_EXE: $umsg" -u :nosuchuser: --stack-trace-frame-limit=1 true
 	if [ -n "$compiled_with_libunwind" ]; then
 		check_e "Stack traces with source line information (-kk/--stack-traces=source option) are not supported by this build of strace" -kk
 		check_e "Stack traces with source line information (-kk/--stack-traces=source option) are not supported by this build of strace" --stack-traces=source

--- a/tests/strace-k-with-depth-limit.expected
+++ b/tests/strace-k-with-depth-limit.expected
@@ -1,0 +1,2 @@
+^chdir ((__)?chdir f3 f2|__kernel_vsyscall (__)?chdir f3) _too_many_stack_frames_
+^SIGURG ((__)?chdir f3 f2|__kernel_vsyscall (__)?chdir f3) _too_many_stack_frames_

--- a/tests/strace-k-with-depth-limit.test
+++ b/tests/strace-k-with-depth-limit.test
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Check strace -k --stack-trace-frame-limit for attached tracees.
+#
+# Copyright (c) 2020-2024 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+KOPT_SHORT=-k
+KOPT_LONG=--stack-traces
+KOPT_EXTRA="--stack-trace-frame-limit 3"
+
+. "${srcdir=.}"/strace-k.test

--- a/tests/strace-k.test
+++ b/tests/strace-k.test
@@ -14,6 +14,7 @@
 : "${ATTACH_MODE=0}"
 : "${KOPT_SHORT=-k}"
 : "${KOPT_LONG=--stack-traces}"
+: "${KOPT_EXTRA=}"
 
 # strace -k is implemented using /proc/$pid/maps
 [ -f /proc/self/maps ] ||
@@ -45,9 +46,9 @@ if [ "x${ATTACH_MODE}" = "x1" ]; then
 			fail_ 'set_ptracer_any failed'
 	done
 
-	run_strace --trace=chdir ${KOPT_LONG} --attach="$tracee_pid"
+	run_strace --trace=chdir ${KOPT_LONG} ${KOPT_EXTRA} --attach="$tracee_pid"
 else
-	run_strace -e chdir ${KOPT_SHORT} $args
+	run_strace -e chdir ${KOPT_SHORT} ${KOPT_EXTRA} $args
 fi
 
 expected="$srcdir/$NAME.expected"
@@ -68,6 +69,11 @@ awk_script_common='
 	} else {
 		out = ""
 	}
+}
+
+/^ > too many stack frames/ {
+	out = out " _too_many_stack_frames_"
+	stop = 1
 }
 
 '


### PR DESCRIPTION
This change adds a `--stacktrace-frames-limit` command line options, which controls the limit of number of frames we print during backtracing (`-k`) a syscall

* NEWS: Mention this
* doc/strace.1.in: Document this
* src/defs.h: New constant DEFAULT_STACKTRACE_FRAMES_LIMIT.
  (unwind_init): Add an int parameter
* src/strace.c (stack_trace_enabled): 
  [ENABLE_STACKTRACE]: Add --stacktrace-frames-limit=N option.
  [ENABLE_STACKTRACE] (init): Handle --stacktrace-frames-limit option.
  (init): Pass the limit to unwind_init() if --stacktrace-frames-limit is given.
* src/unwind.h (struct unwind_unwinder_t::init): Add an int parameter.
* src/unwind.c (unwind_init): Pass the limit parameter to the unwinder initializer.
* src/unwind-libdw.c (tcb_walk): Use the newly added parameter at frame_user_data initialization.
* src/unwind-libunwind.c (walk): Account for the stacktrace_limit when printing stack frames.
* tests/Makefile.am (check_SCRIPTS): add strace-k-with-depth-limit.test. 
  (check_DATA): strace-k-with-depth-limit.expected.
  [ENABLE_STACKTRACE] (STACKTRACE_TESTS): add strace-k-with-depth-limit.test.
* tests/strace-k.test: Add KOPT_EXTRA variable to make the test case reusable for testing --stacktrace-frames-limit option.
* tests/strace-k-with-depth-limit.test: New test case.
* tests/strace-k-with-depth-limit.expected: New file.