### PR TITLE
strace -f: fix potential deadlock during cleanup

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@ Noteworthy changes in release ?.? (????-??-??)
 * Bug fixes
   * Fix strace -r during the first second after booting to show correct relative
     timestamps.
+  * Fix strace -f entering deadlock on exit if there are tracee processes
+    spawned using vfork semantics.
 
 Noteworthy changes in release 6.6 (2023-10-31)
 ==============================================

--- a/src/strace.c
+++ b/src/strace.c
@@ -3100,34 +3100,6 @@ pid2tcb(const int pid)
 }
 
 static void
-cleanup(int fatal_sig)
-{
-	if (ptrace_setoptions & PTRACE_O_EXITKILL)
-		return;
-
-	if (!fatal_sig)
-		fatal_sig = SIGTERM;
-
-	for (size_t i = 0; i < tcbtabsize; ++i) {
-		struct tcb *tcp = tcbtab[i];
-		if (!tcp->pid)
-			continue;
-		debug_func_msg("looking at pid %u", tcp->pid);
-		if (tcp->pid == strace_child) {
-			kill(tcp->pid, SIGCONT);
-			kill(tcp->pid, fatal_sig);
-		}
-		detach(tcp);
-	}
-}
-
-static void
-interrupt(int sig)
-{
-	interrupted = sig;
-}
-
-static void
 print_debug_info(const int pid, int status)
 {
 	const unsigned int event = (unsigned int) status >> 16;
@@ -3164,6 +3136,34 @@ print_debug_info(const int pid, int status)
 		xsprintf(evbuf, ",EVENT_%s (%u)", e, event);
 	}
 	error_msg("[wait(0x%06x) = %u] %s%s", status, pid, buf, evbuf);
+}
+
+static void
+cleanup(int fatal_sig)
+{
+	if (ptrace_setoptions & PTRACE_O_EXITKILL)
+		return;
+
+	if (!fatal_sig)
+		fatal_sig = SIGTERM;
+
+	for (size_t i = 0; i < tcbtabsize; ++i) {
+		struct tcb *tcp = tcbtab[i];
+		if (!tcp->pid)
+			continue;
+		debug_func_msg("looking at pid %u", tcp->pid);
+		if (tcp->pid == strace_child) {
+			kill(tcp->pid, SIGCONT);
+			kill(tcp->pid, fatal_sig);
+		}
+		detach(tcp);
+	}
+}
+
+static void
+interrupt(int sig)
+{
+	interrupted = sig;
 }
 
 static struct tcb *

--- a/src/strace.c
+++ b/src/strace.c
@@ -1148,6 +1148,16 @@ droptcb(struct tcb *tcp)
 	memset(tcp, 0, sizeof(*tcp));
 }
 
+static void
+droptcb_verbose(struct tcb *tcp)
+{
+	if (!is_number_in_set(QUIET_ATTACH, quiet_set)
+	    && (tcp->flags & TCB_ATTACHED))
+		error_msg("Process %u detached", tcp->pid);
+
+	droptcb(tcp);
+}
+
 /* Detach traced process.
  * Never call DETACH twice on the same process as both unattached and
  * attached-unstopped processes give the same ESRCH.  For unattached process we
@@ -1302,11 +1312,7 @@ detach(struct tcb *tcp)
 	}
 
  drop:
-	if (!is_number_in_set(QUIET_ATTACH, quiet_set)
-	    && (tcp->flags & TCB_ATTACHED))
-		error_msg("Process %u detached", tcp->pid);
-
-	droptcb(tcp);
+	droptcb_verbose(tcp);
 }
 
 static void

--- a/src/strace.c
+++ b/src/strace.c
@@ -1033,7 +1033,7 @@ alloctcb(int pid)
 	if (nprocs == tcbtabsize)
 		expand_tcbtab();
 
-	for (unsigned int i = 0; i < tcbtabsize; ++i) {
+	for (size_t i = 0; i < tcbtabsize; ++i) {
 		struct tcb *tcp = tcbtab[i];
 		if (!tcp->pid) {
 			memset(tcp, 0, sizeof(*tcp));
@@ -1447,7 +1447,7 @@ startup_attach(void)
 		debug_msg("new tracer pid is %d", strace_tracer_pid);
 	}
 
-	for (unsigned int tcbi = 0; tcbi < tcbtabsize; ++tcbi) {
+	for (size_t tcbi = 0; tcbi < tcbtabsize; ++tcbi) {
 		tcp = tcbtab[tcbi];
 
 		if (!tcp->pid)
@@ -2761,7 +2761,7 @@ init(int argc, char *argv[])
 		 * of tcbs are not filled though tcbs are initialized.
 		 * We must fill the fields here.
 		 */
-		for (unsigned int i = 0; i < tcbtabsize; ++i) {
+		for (size_t i = 0; i < tcbtabsize; ++i) {
 			struct tcb *tcp = tcbtab[i];
 			if (tcp->comm[0] == 0)
 				maybe_load_task_comm(tcp);
@@ -3090,7 +3090,7 @@ pid2tcb(const int pid)
 	if (tcp && tcp->pid == pid)
 		return tcp;
 
-	for (unsigned int i = 0; i < tcbtabsize; ++i) {
+	for (size_t i = 0; i < tcbtabsize; ++i) {
 		tcp = tcbtab[i];
 		if (tcp->pid == pid)
 			return *ptcp = tcp;
@@ -3108,7 +3108,7 @@ cleanup(int fatal_sig)
 	if (!fatal_sig)
 		fatal_sig = SIGTERM;
 
-	for (unsigned int i = 0; i < tcbtabsize; ++i) {
+	for (size_t i = 0; i < tcbtabsize; ++i) {
 		struct tcb *tcp = tcbtab[i];
 		if (!tcp->pid)
 			continue;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -91,6 +91,7 @@ count-f
 creat
 delay
 delete_module
+detach-vfork
 dev--decode-fds-all
 dev--decode-fds-dev
 dev--decode-fds-none

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -140,6 +140,7 @@ check_PROGRAMS = $(PURE_EXECUTABLES) \
 	close_range \
 	count-f \
 	delay \
+	detach-vfork \
 	execve-v \
 	execveat-v \
 	fcntl--pidns-translation \
@@ -591,6 +592,7 @@ MISC_TESTS = \
 	detach-running.test \
 	detach-sleeping.test \
 	detach-stopped.test \
+	detach-vfork.test \
 	exec-PATH.test \
 	fflush.test \
 	filter-unavailable.test \

--- a/tests/detach-vfork.c
+++ b/tests/detach-vfork.c
@@ -1,0 +1,50 @@
+/*
+ * Check detaching from vfork'ed processes.
+ *
+ * Copyright (c) 2023 Dmitry V. Levin <ldv@strace.io>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "tests.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+int
+main(void)
+{
+	signal(SIGTERM, SIG_IGN);
+
+	pid_t pid = vfork();
+
+	if (pid < 0)
+		perror_msg_and_fail("vfork");
+
+	if (!pid) {
+		sleep(4);
+		_exit(0);
+	}
+
+	int s;
+	pid_t rc;
+	while ((rc = waitpid(pid, &s, 0)) != pid) {
+		if (rc < 0 && errno == EINTR)
+			continue;
+		perror_msg_and_fail("waitpid: %d", pid);
+	}
+
+	const char *exe = getenv("STRACE_EXE") ?: "strace";
+	printf("%s: Process %d attached\n"
+	       "%s: Process %d detached\n"
+	       "%s: Process %d detached\n",
+	       exe, pid, exe, pid, exe, getpid());
+
+	return WIFEXITED(s) ? WEXITSTATUS(s)
+			    : (WIFSIGNALED(s) ? 128 + WTERMSIG(s) : 9);
+}

--- a/tests/detach-vfork.test
+++ b/tests/detach-vfork.test
@@ -1,0 +1,66 @@
+#!/bin/sh
+#
+# Check detaching from vfork'ed processes.
+#
+# Copyright (c) 2023 Dmitry V. Levin <ldv@strace.io>
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+max_wait_attempts=100
+
+run_prog_skip_if_failed \
+	kill -0 $$
+run_prog > /dev/null
+
+> "$LOG"
+$STRACE -I2 -f --trace=none --quiet=personality $args > "$OUT" 2> "$LOG" &
+pid=$!
+
+# Do not wait for strace output forever,
+# stop waiting after $max_wait_attempts iterations.
+attempt=0
+while [ "$attempt" -lt "$max_wait_attempts" ] && [ ! -s "$LOG" ]; do
+	$SLEEP_A_BIT
+	attempt=$((attempt + 1))
+done
+[ -s "$LOG" ] || {
+	kill -9 $pid
+	fail_ 'timeout waiting for strace output'
+}
+
+# Non-empty $LOG means the vfork'ed process has been attached
+# and it's time to send SIGTERM to strace.
+kill $pid
+
+# Do not wait for strace termination forever,
+# stop waiting after $max_wait_attempts iterations.
+attempt=0
+while [ "$attempt" -lt "$max_wait_attempts" ] && kill -0 "$pid" 2> /dev/null; do
+	$SLEEP_A_BIT
+	attempt=$((attempt + 1))
+done
+[ "$attempt" -lt "$max_wait_attempts" ] || {
+	kill -9 $pid
+	fail_ 'timeout waiting for strace to terminate'
+}
+
+rc=0
+wait $pid ||
+	rc=$?
+[ "$rc" = 143 ] ||
+	fail_ "expected exit status 143, got $rc"
+
+# Do not wait for expected output forever,
+# stop waiting after $max_wait_attempts iterations.
+attempt=0
+while [ "$attempt" -lt "$max_wait_attempts" ] && [ ! -s "$OUT" ]; do
+	$SLEEP_A_BIT
+	attempt=$((attempt + 1))
+done
+[ -s "$OUT" ] ||
+	fail_ 'timeout waiting for expected output'
+
+match_diff "$LOG" "$OUT"


### PR DESCRIPTION
strace is likely to block at terminate if tracee is forking. on linux, calling vfork will cause the calling thread to 'D' state until the child process calls execve. But the child process is attached by default and will block when the fork system call returns. therefore strace must detach child process first, otherwise it will enter infinit waiting for the 'D' state thread.

the golang test code:
```
package main
import (
    "os/exec"
    "syscall"
)
var rc = make(chan int, 10)
func run() {
    cmd := exec.Command("sh", []string{"-c", "uname -a"}...)
    attr := syscall.SysProcAttr{ Setpgid: true }
    cmd.SysProcAttr = &attr
    cmd.Run()
    <-rc
    return
}
func main() {
    for {
        rc <- 1
        go run()
    }
}
```
use `go run test.go` to start the test code. and `strace -fp <pid>` attach to the test code. 'Ctrl+c' very likely cannot stop the strace.