### PR TITLE
Fix strace -r during the second after booting

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ Noteworthy changes in release ?.? (????-??-??)
   * Updated lists of BPF_*, BTRFS_*, IORING_*, KVM_*, LANDLOCK_*, PR_*,
     and TCP_* constants.
 
+* Bug fixes
+  * Fix strace -r during the first second after booting to show correct relative
+    timestamps.
+
 Noteworthy changes in release 6.6 (2023-10-31)
 ==============================================
 

--- a/src/strace.c
+++ b/src/strace.c
@@ -908,7 +908,7 @@ printleader(struct tcb *tcp)
 		clock_gettime(CLOCK_MONOTONIC, &ts);
 
 		static struct timespec ots;
-		if (ots.tv_sec == 0)
+		if (ots.tv_sec == 0 && ots.tv_nsec == 0)
 			ots = ts;
 
 		struct timespec dts;


### PR DESCRIPTION
strace -r decides whether the previous timespec has been initialized by
checking if `tv_sec == 0`. However, in the second after booting,
`CLOCK_MONOTONIC` will legitimately have a `tv_sec` of 0. This causes every
displayed timestamp to display as `0.000000` during the second after boot.

Check `tv_nsec` as well before assuming the previous timespec is uninitialized.

-----

Originally discovered in a freshly booted virtual system, amusingly while
trying to use strace to debug a similar issue in ping:
https://github.com/iputils/iputils/pull/499
