### PR TITLE
src/count.c: fix build against upcoming `gcc-14` (`-Werror=calloc-tra…

### DIFF
--- a/src/count.c
+++ b/src/count.c
@@ -316,7 +316,7 @@ call_summary_pers(FILE *outf)
 
 
 	/* sort, calculate statistics */
-	indices = xcalloc(sizeof(indices[0]), nsyscalls);
+	indices = xcalloc(nsyscalls, sizeof(indices[0]));
 	for (size_t i = 0; i < nsyscalls; ++i) {
 		indices[i] = i;
 		if (counts[i].calls == 0)


### PR DESCRIPTION
…nsposed-args`)

`gcc-14` added a new `-Wcalloc-transposed-args` warning recently. It detected minor infelicity in `calloc()` API usage in `strace`:

    count.c:319:33: error: 'strace_calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
      319 |         indices = xcalloc(sizeof(indices[0]), nsyscalls);
          |                                 ^