### PR TITLE
v4l2: add VIDIOC_QBUF_TIME32 and friends

### DIFF
--- a/src/kernel_v4l2_types.h
+++ b/src/kernel_v4l2_types.h
@@ -46,6 +46,48 @@ typedef struct {
 	};
 } kernel_v4l2_buffer_t;
 
+# if HAVE_ARCH_TIME32_SYSCALLS || HAVE_ARCH_TIMESPEC32
+#  define KERNEL_V4L2_HAVE_TIME32 1
+
+/*
+ * On all 32-bit architectures and on 64-bit ones with COMPAT enabled
+ * some syscalls can have both variants: with 64 bit and with 32 bit time.
+ *
+ * See COMPAT_32BIT_TIME in kernel/arch/Kconfig
+ */
+
+/* See kernel/include/vdso/time32.h */
+typedef struct kernel_old_timeval32_t {
+	int32_t	tv_sec;
+	int32_t	tv_usec;
+} kernel_old_timeval32_t;
+
+/* See kernel/include/media/v4l2-ioctl.h */
+typedef struct {
+	uint32_t			index;
+	uint32_t			type;
+	uint32_t			bytesused;
+	uint32_t			flags;
+	uint32_t			field;
+	kernel_old_timeval32_t		timestamp;
+	struct v4l2_timecode		timecode;
+	uint32_t			sequence;
+	uint32_t			memory;
+	union {
+		uint32_t		offset;
+		unsigned long		userptr;
+		struct v4l2_plane	*planes;
+		int32_t			fd;
+	} m;
+	uint32_t			length;
+	uint32_t			reserved2;
+	union {
+		int32_t			request_fd;
+		uint32_t		reserved;
+	};
+} kernel_v4l2_buffer_time32_t;
+# endif /* HAVE_ARCH_TIME32_SYSCALLS || HAVE_ARCH_TIMESPEC32 */
+
 typedef struct {
 	uint32_t				type;
 	union {
@@ -84,6 +126,20 @@ typedef struct {
 
 # undef VIDIOC_PREPARE_BUF
 # define VIDIOC_PREPARE_BUF	_IOWR('V',  93, kernel_v4l2_buffer_t)
+
+#ifdef KERNEL_V4L2_HAVE_TIME32
+# undef VIDIOC_QUERYBUF_TIME32
+# define VIDIOC_QUERYBUF_TIME32	_IOWR('V',   9, kernel_v4l2_buffer_time32_t)
+
+# undef VIDIOC_QBUF_TIME32
+# define VIDIOC_QBUF_TIME32		_IOWR('V',  15, kernel_v4l2_buffer_time32_t)
+
+# undef VIDIOC_DQBUF_TIME32
+# define VIDIOC_DQBUF_TIME32		_IOWR('V',  17, kernel_v4l2_buffer_time32_t)
+
+# undef VIDIOC_PREPARE_BUF_TIME32
+# define VIDIOC_PREPARE_BUF_TIME32	_IOWR('V',  93, kernel_v4l2_buffer_time32_t)
+#endif
 
 /*
  * Constants based on struct v4l2_event are unreliable

--- a/tests/ioctl_v4l2.c
+++ b/tests/ioctl_v4l2.c
@@ -793,6 +793,42 @@ main(void)
 	       "})" RVAL_EBADF,
 	       XLAT_STR(VIDIOC_DQBUF), p_v4l2_buffer->type);
 
+#ifdef KERNEL_V4L2_HAVE_TIME32
+	/* VIDIOC_QUERYBUF_TIME32 */
+	ioctl(-1, VIDIOC_QUERYBUF_TIME32, 0);
+	printf("ioctl(-1, %s, NULL)" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_QUERYBUF_TIME32));
+
+	kernel_v4l2_buffer_time32_t *const p_v4l2_buffer_time32 =
+		page_end - sizeof(*p_v4l2_buffer_time32);
+	ioctl(-1, VIDIOC_QUERYBUF_TIME32, p_v4l2_buffer_time32);
+	printf("ioctl(-1, %s, {type=%#x" NRAW(" /* V4L2_BUF_TYPE_??? */")
+	       ", index=%u})" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_QUERYBUF_TIME32),
+	       p_v4l2_buffer_time32->type, p_v4l2_buffer_time32->index);
+
+	/* VIDIOC_QBUF_TIME32 */
+	ioctl(-1, VIDIOC_QBUF_TIME32, 0);
+	printf("ioctl(-1, %s, NULL)" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_QBUF_TIME32));
+
+	ioctl(-1, VIDIOC_QBUF_TIME32, p_v4l2_buffer_time32);
+	printf("ioctl(-1, %s, {type=%#x" NRAW(" /* V4L2_BUF_TYPE_??? */")
+	       ", index=%u})" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_QBUF_TIME32),
+	       p_v4l2_buffer_time32->type, p_v4l2_buffer_time32->index);
+
+	/* VIDIOC_DQBUF_TIME32 */
+	ioctl(-1, VIDIOC_DQBUF_TIME32, 0);
+	printf("ioctl(-1, %s, NULL)" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_DQBUF_TIME32));
+
+	ioctl(-1, VIDIOC_DQBUF_TIME32, p_v4l2_buffer_time32);
+	printf("ioctl(-1, %s, {type=%#x" NRAW(" /* V4L2_BUF_TYPE_??? */")
+	       "})" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_DQBUF_TIME32), p_v4l2_buffer_time32->type);
+#endif
+
 	/* VIDIOC_G_FBUF */
 	ioctl(-1, VIDIOC_G_FBUF, 0);
 	printf("ioctl(-1, %s, NULL)" RVAL_EBADF,


### PR DESCRIPTION
On 32-bit kernels there are older variants of VIDIOC_QBUF, VIDIOC_DQBUF, and VIDIOC_QUERYBUF ioctls, which have _TIME32 suffix. These are for old timeval_t with 32-bit timestamps. Some 32-bit applications still use these.

Implement printing these variants alongside regular 64-bit time ones.