### PR TITLE
Print pid prefix for all processes in followfork mode

### DIFF
--- a/src/strace.c
+++ b/src/strace.c
@@ -870,7 +870,7 @@ printleader(struct tcb *tcp)
 	set_current_tcp(tcp);
 	current_tcp->curcol = 0;
 
-	if (print_pid_pfx || (nprocs > 1 && !outfname)) {
+	if (print_pid_pfx || ((followfork || nprocs > 1) && !outfname)) {
 		size_t len = is_number_in_set(DECODE_PID_COMM, decode_pid_set)
 			     ? strlen(tcp->comm) : 0;
 


### PR DESCRIPTION
* src/strace.c: Check for followfork in pid prefix condition.

Resolves: https://github.com/strace/strace/issues/278