### PR TITLE
Make -p options accept multiple delimiters between PIDs

### DIFF
--- a/src/strace.c
+++ b/src/strace.c
@@ -1348,7 +1348,12 @@ process_opt_p_list(char *opt)
 		 * pidof uses space as delim, pgrep uses newline. :(
 		 */
 		int pid;
-		char *delim = opt + strcspn(opt, "\n\t ,");
+		size_t adv = strcspn(opt, "\n\t ,");
+		if (adv == 0) {
+			opt++;
+			continue;
+		}
+		char *delim = opt + adv;
 		char c = *delim;
 
 		*delim = '\0';

--- a/tests/options-syntax.test
+++ b/tests/options-syntax.test
@@ -437,6 +437,14 @@ $STRACE_EXE: $umsg" -u :nosuchuser: --stack-trace-frame-limit=1 true
 	fi
 fi
 
+check_zero -p "$$  $$" -V
+check_zero -p "$$   $$" -V
+check_zero -p "$$    $$" -V
+check_zero -p "$$,,$$" -V
+check_zero -p "$$, ,$$" -V
+check_zero -p "$$, , ,$$" -V
+check_zero -p "$$, ,, ,$$" -V
+
 args='-p 2147483647'
 $STRACE $args 2> "$LOG" &&
 	dump_log_and_fail_with \

--- a/tests/syntax.sh
+++ b/tests/syntax.sh
@@ -15,6 +15,17 @@ log_sfx()
 	printf "%.128s" "$*" | tr -c '0-9A-Za-z-=,' '_'
 }
 
+check_zero()
+{
+	local sfx
+	sfx="$(log_sfx "$*")"
+
+	$STRACE "$@" 2> "$LOG.$sfx" > /dev/null || {
+		cat "$LOG.$sfx" >&2
+		fail_ "strace $* failed to handle the error properly"
+	}
+}
+
 check_exit_status_and_stderr()
 {
 	local sfx


### PR DESCRIPTION
The original code accepts only one delimiter between PIDs. This change relaxes the condition.

* src/strace.c (process_opt_p_list): Skip the consecutive delimiters.
* tests/syntax.sh (check_zero): New helper function.
* tests/options-syntax.test: Add code testing this change.

