### PR TITLE
strace: add support for -u UID:GID that bypasses lookup

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@ Noteworthy changes in release ?.? (????-??-??)
 ==============================================
 
 * Improvements
+  * The --user|-u option has learned to recognize numeric UID:GID pair, allowing
+    e.g. statically-built strace to be used without invoking nss plugins.
 
 Noteworthy changes in release 6.8 (2024-03-20)
 ==============================================

--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -358,6 +358,13 @@ This option is only useful when running as root and enables the
 correct execution of setuid and/or setgid binaries.
 Unless this option is used setuid and setgid programs are executed
 without effective privileges.
+.TQ
+.BI "\-u " UID:GID
+.TQ
+.BR "\-\-user" = \fIUID:GID\fR
+Alternative syntax where the program is started with exactly the given user
+and group IDs, and an empty list of supplementary groups.  In this case,
+user and group name lookups are not performed.
 .TP
 .BR "\-\-argv0" = \fIname\fR
 Set argv[0] of the command being executed to

--- a/tests/options-syntax.test
+++ b/tests/options-syntax.test
@@ -342,14 +342,26 @@ diff -u -- "$EXP" "$LOG" > /dev/null || {
 		"zeroargc $STRACE $args output mismatch"
 }
 
+check_uid_gid_syntax()
+{
+	check_e "Invalid UID:GID pair 'uid:gid'" -u uid:gid true
+	check_e "Invalid UID:GID pair '4294967295:4294967294'" \
+		-u 4294967295:4294967294 true
+	check_e "Invalid UID:GID pair '4294967294:4294967295'" \
+		-u 4294967294:4294967295 true
+	run_strace --user="$(id -u):$(id -g)" -qq -enone /bin/true
+}
+
 uid="${UID:-`id -u`}"
 if [ "$uid" -ge 0 ]; then
 	if [ "$uid" -eq 0 ]; then
+		check_uid_gid_syntax
 		umsg="Cannot find user '!no such user!'"
 	else
 		if [ "$(fakeroot ../block_reset_run 15 id -u 2>&1)" = 0 ]; then
 			saved_STRACE=$STRACE
 			STRACE="fakeroot -- $STRACE"
+			check_uid_gid_syntax
 			umsg="Cannot find user '!no such user!'"
 			check_e "$umsg" -u '!no such user!' true
 			STRACE=$saved_STRACE

--- a/tests/options-syntax.test
+++ b/tests/options-syntax.test
@@ -345,23 +345,23 @@ diff -u -- "$EXP" "$LOG" > /dev/null || {
 uid="${UID:-`id -u`}"
 if [ "$uid" -ge 0 ]; then
 	if [ "$uid" -eq 0 ]; then
-		umsg="Cannot find user ':nosuchuser:'"
+		umsg="Cannot find user '!no such user!'"
 	else
 		if [ "$(fakeroot ../block_reset_run 15 id -u 2>&1)" = 0 ]; then
 			saved_STRACE=$STRACE
 			STRACE="fakeroot -- $STRACE"
-			umsg="Cannot find user ':nosuchuser:'"
-			check_e "$umsg" -u :nosuchuser: true
+			umsg="Cannot find user '!no such user!'"
+			check_e "$umsg" -u '!no such user!' true
 			STRACE=$saved_STRACE
 		fi
 		umsg='You must be root to use the -u/--username option'
 	fi
 
-	check_e "$umsg" -u :nosuchuser: true
+	check_e "$umsg" -u '!no such user!' true
 
 	for c in i/--instruction-pointer n/--syscall-number r/--relative-timestamps t/--absolute-timestamps T/--syscall-times y/--decode-fds; do
 		check_e "-$c has no effect with -c/--summary-only
-$STRACE_EXE: $umsg" -u :nosuchuser: -c -${c%%/*} true
+$STRACE_EXE: $umsg" -u '!no such user!' -c -${c%%/*} true
 	done
 
 	check_e "-i/--instruction-pointer has no effect with -c/--summary-only
@@ -371,47 +371,47 @@ $STRACE_EXE: -t/--absolute-timestamps has no effect with -c/--summary-only
 $STRACE_EXE: -T/--syscall-times has no effect with -c/--summary-only
 $STRACE_EXE: -y/--decode-fds has no effect with -c/--summary-only
 $STRACE_EXE: Only the last of -z/--successful-only/-Z/--failed-only options will take effect. See status qualifier for more complex filters.
-$STRACE_EXE: $umsg" -u :nosuchuser: -cinrtTyzZ true
+$STRACE_EXE: $umsg" -u '!no such user!' -cinrtTyzZ true
 
 	if [ -n "$compiled_with_secontext" ]; then
 		check_e "--secontext has no effect with -c/--summary-only
-$STRACE_EXE: $umsg" -u :nosuchuser: -c --secontext true
+$STRACE_EXE: $umsg" -u '!no such user!' -c --secontext true
 	else
 		check_e "SELinux context printing (--secontext option) is not supported by this build of strace" -c --secontext true
 	fi
 
 	if [ -n "$compiled_with_stacktrace" ]; then
 		check_e "-k/--stack-trace has no effect with -c/--summary-only
-$STRACE_EXE: $umsg" -u :nosuchuser: -c -k true
+$STRACE_EXE: $umsg" -u '!no such user!' -c -k true
 	fi
 
 	for c in --output-separately -A/--output-append-mode; do
 		check_e "$c has no effect without -o/--output
-$STRACE_EXE: $umsg" -u :nosuchuser: ${c%%/*} true
+$STRACE_EXE: $umsg" -u '!no such user!' ${c%%/*} true
 	done
 
 	check_e "-S/--summary-sort-by has no effect without (-c/--summary-only or -C/--summary)
-$STRACE_EXE: $umsg" -u :nosuchuser: --summary-sort-by errors true
+$STRACE_EXE: $umsg" -u '!no such user!' --summary-sort-by errors true
 
 	check_e "--output-separately has no effect without -o/--output
 $STRACE_EXE: -A/--output-append-mode has no effect without -o/--output
-$STRACE_EXE: $umsg" -u :nosuchuser: --output-separately --output-append-mode true
+$STRACE_EXE: $umsg" -u '!no such user!' --output-separately --output-append-mode true
 
-	check_e "$umsg" -u :nosuchuser: -ff true
-	check_e "$umsg" -u :nosuchuser: --output-separately --follow-forks true
+	check_e "$umsg" -u '!no such user!' -ff true
+	check_e "$umsg" -u '!no such user!' --output-separately --follow-forks true
 
 	check_e "Only the last of -z/--successful-only/-Z/--failed-only options will take effect. See status qualifier for more complex filters.
-$STRACE_EXE: $umsg" -u :nosuchuser: -z --successful-only true
+$STRACE_EXE: $umsg" -u '!no such user!' -z --successful-only true
 	check_e "Only the last of -z/--successful-only/-Z/--failed-only options will take effect. See status qualifier for more complex filters.
-$STRACE_EXE: $umsg" -u :nosuchuser: --successful-only -Z true
+$STRACE_EXE: $umsg" -u '!no such user!' --successful-only -Z true
 	check_e "Only the last of -z/--successful-only/-Z/--failed-only options will take effect. See status qualifier for more complex filters.
-$STRACE_EXE: $umsg" -u :nosuchuser: --successful-only --failed-only true
+$STRACE_EXE: $umsg" -u '!no such user!' --successful-only --failed-only true
 
 	check_e "-n/--syscall-number has no effect with -c/--summary-only
-$STRACE_EXE: $umsg" --user=:nosuchuser: --syscall-number --summary-only true
+$STRACE_EXE: $umsg" --user='!no such user!' --syscall-number --summary-only true
 
 	check_e "-i/--instruction-pointer has no effect with -c/--summary-only
-$STRACE_EXE: $umsg" --user=:nosuchuser: --instruction-pointer --summary-only true
+$STRACE_EXE: $umsg" --user='!no such user!' --instruction-pointer --summary-only true
 fi
 
 check_e_using_grep 'ptrace_setoptions = 0x[[:xdigit:]]+' -d /
@@ -431,7 +431,7 @@ if [ -z "$compiled_with_stacktrace" ]; then
 		--stack-trace-frame-limit=1
 else
 	check_e "--stack-trace-frame-limit has no effect without -k/--stack-trace
-$STRACE_EXE: $umsg" -u :nosuchuser: --stack-trace-frame-limit=1 true
+$STRACE_EXE: $umsg" -u '!no such user!' --stack-trace-frame-limit=1 true
 	if [ -n "$compiled_with_libunwind" ]; then
 		check_e "Stack traces with source line information (-kk/--stack-trace=source option) are not supported by this build of strace" -kk
 		check_e "Stack traces with source line information (-kk/--stack-trace=source option) are not supported by this build of strace" --stack-trace=source


### PR DESCRIPTION
When building strace statically linked using the "--username" argument will lead to strange errors. The reason is that the calls to getpwnam() and initgroups() will fail because glibc will still try to dlopen() the libnss modules which then fails in unexpected ways.

The `--username` argument is only needed for uid:gid and supplementary groups setup. So this commit provides a way to pass uid:gid via the commandline and it will not init supplementary groups (but it could be extended for this).

This does allow to use a statically linked strace.