### PR TITLE
Show the slave device for the fd opening /dev/ptmx when -yy is given

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -682,11 +682,14 @@ struct finfo {
 	bool deleted;
 	struct {
 		unsigned int major, minor;
+
+		/* Use only when major == 5, minor == 2 (/dev/ptmx) */
+		int tty_index;
 	} dev;
 };
 
 extern struct finfo *
-get_finfo_for_dev(const char *path, struct finfo *finfo);
+get_finfo_for_dev(pid_t pid, int fd, const char *path, struct finfo *finfo);
 
 extern int
 term_ioctl_decode_command_number(struct tcb *tcp,

--- a/src/ioctl.c
+++ b/src/ioctl.c
@@ -461,7 +461,7 @@ SYS_FUNC(ioctl)
 		if (ioctl_command_overlaps(tcp->u_arg[1]) &&
 		    getfdpath_pid(tcp->pid, tcp->u_arg[0], path, sizeof(path),
 				  &deleted) >= 0) {
-			finfo = get_finfo_for_dev(path, &finfoa);
+			finfo = get_finfo_for_dev(tcp->pid, tcp->u_arg[0], path, &finfoa);
 			finfo->deleted = deleted;
 			printfd_with_finfo(tcp, tcp->u_arg[0], finfo);
 		} else

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -97,6 +97,7 @@ dev--decode-fds-dev
 dev--decode-fds-none
 dev--decode-fds-path
 dev--decode-fds-socket
+dev-pty-yy
 dev-yy
 dup
 dup-P

--- a/tests/dev-pty-yy.c
+++ b/tests/dev-pty-yy.c
@@ -1,0 +1,40 @@
+/*
+ * Check printing of the counter endpoint of /dev/ptmx in -yy mode.
+ *
+ * Copyright (c) 2024 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "tests.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+int
+main(void)
+{
+	static const char dev_ptmx[] = "/dev/ptmx";
+	int ptmx_fd = open(dev_ptmx, O_RDWR|O_NOCTTY);
+	if (ptmx_fd < 0)
+		perror_msg_and_skip("open: %s", dev_ptmx);
+
+	if (unlockpt(ptmx_fd) < 0)
+		perror_msg_and_skip("unlockpt");
+
+	const char *pts = ptsname(ptmx_fd);
+	if (pts == NULL)
+		error_msg_and_skip("failed in ptsname()");
+
+	const char *real_ptmx = get_fd_path(ptmx_fd);
+	int rc = close(ptmx_fd);
+	printf("close(%d<%s<char 5:2 @%s>>) = %d\n",
+	       ptmx_fd, real_ptmx, pts, rc);
+
+	puts("+++ exited with 0 +++");
+	return 0;
+}

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -82,6 +82,7 @@ dev--decode-fds-dev	-a30 -e trace=openat,fsync -P "/dev/full" -P "/dev/zero" -P 
 dev--decode-fds-none	-a9 -e trace=openat,fsync -P "/dev/full" -P "/dev/zero" -P "/dev/sda" --decode-fds=none
 dev--decode-fds-path	-a19 -e trace=openat,fsync -P "/dev/full" -P "/dev/zero" -P "/dev/sda" -e decode-fds=path
 dev--decode-fds-socket	-a9 -e trace=openat,fsync -P "/dev/full" -P "/dev/zero" -P "/dev/sda" --decode-fds=socket
+dev-pty-yy -a30 -e trace=close -P "/dev/ptmx" -yy
 dev-yy	-a30 -e trace=openat,fsync -P "/dev/full" -P "/dev/zero" -P "/dev/sda" -yy
 dup	-a7 9>>/dev/full
 dup-P	-a7 --trace=dup -P /dev/full 9>>/dev/full

--- a/tests/pure_executables.list
+++ b/tests/pure_executables.list
@@ -52,6 +52,7 @@ dev--decode-fds-dev
 dev--decode-fds-none
 dev--decode-fds-path
 dev--decode-fds-socket
+dev-pty-yy
 dev-yy
 dup
 dup-P


### PR DESCRIPTION
An example output:

     read(32</dev/ptmx<char 5:2->/dev/pts/7>>, "\0\"\\0", 4) = 4

* src/defs.h (struct finfo::tty_index): New member. (get_finfo_for_dev): Add two parameters.
* src/ioctl.c (SYS_FUNC(ioctl)): Pass pid and fd to get_finfo_for_dev().
* src/utils.c (scan_fdinfo, scan_fdinfo_fn): Declare earlier. (is_ptmx): New macro.
(get_pts): New function.
(get_finfo_for_dev): Read the tty-index field in /proc/$pid/fdinfo/$fd and store the value to struct finfo::tty_index.
(printenv): Pass pid and fd to get_finfo_for_dev(). Print the slave device for the fd opening /dev/ptmx as the counter endpoint.
* tests/dev-pty-yy.c: New test case.
* tests/gen_tests.in: Add dev-pty-yy.
* tests/pure_executables.list: Add dev-pty-yy.