### PR TITLE
Add option --always-show-pid

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ Noteworthy changes in release ?.? (????-??-??)
 ==============================================
 
 * Improvements
+  * Implemented --always-show-pid option.
   * The --user|-u option has learned to recognize numeric UID:GID pair, allowing
     e.g. statically-built strace to be used without invoking nss plugins.
   * Updated decoding of pidfd_send_signal syscall.

--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -1307,6 +1307,11 @@ Print command names for PIDs.
 .if '@ENABLE_SECONTEXT_FALSE@'#' .BR !full,mismatch
 .if '@ENABLE_SECONTEXT_FALSE@'#' which prints only the type instead of full context
 .if '@ENABLE_SECONTEXT_FALSE@'#' and doesn't check for context mismatches.
+.TP
+.B \-\-always\-show\-pid
+Show PID prefix also for the process started by strace.
+Implied when \-f and \-o are both specified.
+.RE
 .SS Statistics
 .TP 12
 .B \-c

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1085,6 +1085,7 @@ status-successful-threads
 status-unfinished
 status-unfinished-threads
 statx
+strace--always-show-pid
 strace--decode-pids-comm
 strace--strings-in-hex
 strace--strings-in-hex-all

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -1068,6 +1068,7 @@ strace--absolute-timestamps-format-unix-precision-ms +strace-ttt.test 3 --absolu
 strace--absolute-timestamps-format-unix-precision-ns +strace-ttt.test 9 --absolute-timestamps=format:unix --absolute-timestamps=precision:ns
 strace--absolute-timestamps-format-unix-precision-s +strace-ttt.test 0 --absolute-timestamps=format:unix --absolute-timestamps=precision:s
 strace--absolute-timestamps-format-unix-precision-us +strace-ttt.test 6 --absolute-timestamps=precision:us --absolute-timestamps=format:unix
+strace--always-show-pid	--always-show-pid --trace=fchdir -a15
 strace--decode-pids-comm	--decode-pids=comm --trace=getppid,tgkill --signal='!SIGCHLD,SIGCONT' -q -f -a 18
 strace--follow-forks-output-separately +strace-ff.test --follow-forks --output-separately
 strace--relative-timestamps +strace-r.test --relative-timestamps

--- a/tests/pure_executables.list
+++ b/tests/pure_executables.list
@@ -784,6 +784,7 @@ status-successful-long
 status-successful-status
 status-unfinished
 statx
+strace--always-show-pid
 strace--strings-in-hex
 strace--strings-in-hex-all
 strace--strings-in-hex-non-ascii

--- a/tests/strace--always-show-pid.c
+++ b/tests/strace--always-show-pid.c
@@ -1,0 +1,22 @@
+/*
+ * Check the PID prefix output with --always-show-pid option.
+ *
+ * Copyright (c) 2024 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "tests.h"
+#include <stdio.h>
+#include <unistd.h>
+
+int
+main(void)
+{
+	const int pid = getpid();
+	printf("%-5u fchdir(-1) = %s\n", pid, sprintrc(fchdir(-1)));
+
+	printf("%-5u +++ exited with 0 +++\n", pid);
+	return 0;
+}


### PR DESCRIPTION
By default, PID prefixes are only printed for children forked from the process started by strace. With this option, prefixes are printed for the process started by strace as well.

Close #278