### PR TITLE
auxstr: print the namespaces where the traceee switches to

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,8 @@ Noteworthy changes in release 6.10 (2024-07-21)
   * Updated lists of BPF_*, IORING_*, KEXEC_*, KEY_*, LANDLOCK_*, PR_*, STATX_*,
     TCP_*, TEE_*, V4L2_*, and *_MAGIC constants.
   * Updated lists of ioctl commands from Linux 6.10.
+  * Added -e namespace=new option for printing the namespaces that the tracee
+    enters.
 
 * Bug fixes
   * Worked around a bug introduced in Linux 6.5 that affected system call

--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -999,6 +999,13 @@ if the tracee is in a different PID namespace.
 Print the exit reason of kvm vcpu.  Requires Linux kernel version 4.16.0
 or higher.
 .TP
+.BR "\-e\ namespace" = new
+.TQ
+.BR "\-\-namespace" = new
+Print the new namespaces that the tracee enters.
+\fBclone (2)\fR, \fBclone3 (2)\fR, \fBsetns (2)\fR, and \fBunshare (2)\fR
+are supported.
+.TP
 .B \-i
 .TQ
 .B \-\-instruction\-pointer

--- a/src/defs.h
+++ b/src/defs.h
@@ -1440,6 +1440,7 @@ extern void qualify_write(const char *);
 extern void qualify_fault(const char *);
 extern void qualify_inject(const char *);
 extern void qualify_kvm(const char *);
+extern void qualify_namespace(const char *);
 extern unsigned int qual_flags(const unsigned int);
 
 # define DECL_IOCTL(name)						\
@@ -1595,6 +1596,8 @@ extern void unwind_tcb_capture(struct tcb *);
 extern void kvm_run_structure_decoder_init(void);
 extern void kvm_vcpu_info_free(struct tcb *);
 # endif
+
+extern void namespace_auxstr_init(void);
 
 extern void maybe_load_task_comm(struct tcb *tcp);
 /* Print the contents of /proc/$pid/comm. */

--- a/src/filter_qualify.c
+++ b/src/filter_qualify.c
@@ -633,6 +633,16 @@ qualify_kvm(const char *const str)
 	}
 }
 
+void
+qualify_namespace(const char *const str)
+{
+	if (strcmp(str, "new") == 0) {
+		namespace_auxstr_init();
+	} else {
+		error_msg_and_die("invalid -e namespace= argument: '%s'", str);
+	}
+}
+
 #ifdef ENABLE_SECONTEXT
 struct number_set *secontext_set;
 
@@ -699,6 +709,7 @@ static const struct qual_options {
 	{ "decode-pid",	qualify_decode_pid },
 	{ "decode-pids", qualify_decode_pid },
 	{ "secontext",  qualify_secontext },
+	{ "namespace",  qualify_namespace },
 };
 
 void

--- a/src/strace.c
+++ b/src/strace.c
@@ -377,6 +377,8 @@ Output format:\n\
      messages:   attach, exit, path-resolution, personality, thread-execve\n\
   -e kvm=vcpu, --kvm=vcpu\n\
                  print exit reason of kvm vcpu\n\
+  -e namespace=new, --namespace=new\n\
+                 print namespace IDs that the tracee enters\n\
   -e decode-fds=SET, --decode-fds=SET\n\
                  what kinds of file descriptor information details to decode\n\
      details:    dev (device major/minor for block/char device files),\n\
@@ -2281,6 +2283,7 @@ init(int argc, char *argv[])
 	static const char ttflag_str[] = "precision:us,format:time";
 	static const char tttflag_str[] = "format:unix,precision:us";
 	static const char secontext_qual[] = "!full,mismatch";
+	static const char namespace_qual[] = "new";
 
 	int c, i;
 	int optF = 0, zflags = 0;
@@ -2381,6 +2384,7 @@ init(int argc, char *argv[])
 		GETOPT_QUAL_FAULT,
 		GETOPT_QUAL_INJECT,
 		GETOPT_QUAL_KVM,
+		GETOPT_QUAL_NAMESPACE,
 		GETOPT_QUAL_QUIET,
 		GETOPT_QUAL_DECODE_FD,
 		GETOPT_QUAL_DECODE_PID,
@@ -2447,6 +2451,7 @@ init(int argc, char *argv[])
 		{ "fault",	required_argument, 0, GETOPT_QUAL_FAULT },
 		{ "inject",	required_argument, 0, GETOPT_QUAL_INJECT },
 		{ "kvm",	required_argument, 0, GETOPT_QUAL_KVM },
+		{ "namespace",  optional_argument, 0, GETOPT_QUAL_NAMESPACE },
 		{ "quiet",	optional_argument, 0, GETOPT_QUAL_QUIET },
 		{ "silent",	optional_argument, 0, GETOPT_QUAL_QUIET },
 		{ "silence",	optional_argument, 0, GETOPT_QUAL_QUIET },
@@ -2770,6 +2775,9 @@ init(int argc, char *argv[])
 			break;
 		case GETOPT_QUAL_KVM:
 			qualify_kvm(optarg);
+			break;
+		case GETOPT_QUAL_NAMESPACE:
+			qualify_namespace(optarg ?: namespace_qual);
 			break;
 		case GETOPT_QUAL_QUIET:
 			qualify_quiet(optarg ?: qflag_qual);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -72,6 +72,7 @@ clone3
 clone3-Xabbrev
 clone3-Xraw
 clone3-Xverbose
+clone3-report-ns-id
 clone3-success
 clone3-success-Xabbrev
 clone3-success-Xraw

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1046,6 +1046,7 @@ setgroups
 setgroups32
 sethostname
 setns
+setns-report-ns-id
 setpgrp-exec
 setregid
 setregid32

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1208,6 +1208,7 @@ unix-pair-sendto-recvfrom
 unlink
 unlinkat
 unshare
+unshare-report-ns-id
 userfaultfd
 ustat
 utime

--- a/tests/clone-flags.test
+++ b/tests/clone-flags.test
@@ -21,4 +21,4 @@ CHILD_STACK_REPORTED="$(sed -n 's/^clone[^(]*(child_stack=\(0x[[:xdigit:]]\+\),.
 export CHILD_STACK_EXPECTED CHILD_STACK_REPORTED
 
 # Use child stack addresses to check decoding.
-run_strace_match_diff -a35 --silence=exits,personality -y -e signal=none -e trace=$syscall
+run_strace_match_diff -a35 --silence=exits,personality -y -e signal=none -e trace=$syscall -e namespace=new

--- a/tests/clone3-report-ns-id.c
+++ b/tests/clone3-report-ns-id.c
@@ -1,0 +1,42 @@
+/*
+ * Check appending auxstr of clone3(2) when --namespace=switchTo is given
+ *
+ * Copyright (c) 2024 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "tests.h"
+#include "xmalloc.h"
+
+#include <limits.h>
+#include <linux/sched.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "scno.h"
+
+int
+main(void)
+{
+	struct clone_args arg = { .flags = CLONE_NEWUSER };
+	int pid = syscall(__NR_clone3, &arg, sizeof(arg));
+	if (pid < 0)
+		perror_msg_and_fail("clone3");
+	if (pid > 0) {
+		printf("clone3({flags=CLONE_NEWUSER, exit_signal=0, stack=NULL, stack_size=0}"
+		       ", %zu) = %s ", sizeof(arg), sprintrc(pid));
+
+		char userns[PATH_MAX + 1];
+		char *fname = xasprintf("/proc/%d/ns/user", pid);
+		int rc = readlink(fname, userns, sizeof(userns));
+		if ((size_t) rc >= sizeof(userns))
+			perror_msg_and_fail("readlink");
+		userns[rc] = '\0';
+		printf("(%s)\n", userns);
+		puts("+++ exited with 0 +++");
+	}
+	return 0;
+}

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -1030,6 +1030,7 @@ setgroups	-s2 -a17
 setgroups32	-s2 -a19
 sethostname	-a22
 setns	-a21
+setns-report-ns-id	-a11	-e trace=setns -e namespace=new -e signal=none
 setregid	-a15
 setregid32	-a17
 setresgid	-a19

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -1219,6 +1219,7 @@ umovestr_cached_adjacent	+umovestr_cached.test 3
 unlink	-a24
 unlinkat	-a35
 unshare	-a11
+unshare-report-ns-id	-a11	-e trace=unshare -e namespace=new
 userfaultfd	-a15
 ustat	-a33
 utime	-a16

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -66,6 +66,7 @@ clone3-success-Xabbrev	-einject=clone3:retval=42 -etrace=clone3 -a16 -Xabbrev
 clone3-success-Xraw	-einject=clone3:retval=42 -etrace=clone3 -a16 -Xraw
 clone3-success-Xverbose	-einject=clone3:retval=42 -etrace=clone3 -a16 -Xverbose
 clone_parent +clone_ptrace.test
+clone3-report-ns-id	-etrace=clone3 -a35 -e namespace=new
 clone_parent--quiet-exit +clone_ptrace.test --quiet=exit,personality
 clone_parent-q +clone_ptrace.test -q
 clone_parent-qq +clone_ptrace.test -qq

--- a/tests/options-syntax.test
+++ b/tests/options-syntax.test
@@ -280,6 +280,9 @@ check_h 'deprecated option -F ignored
 check_e "invalid -e kvm= argument: 'chdir'" -e kvm=chdir
 check_e "invalid -e kvm= argument: 'chdir'" --kvm=chdir
 
+check_e "invalid -e namespace= argument: 'NOSUCHITEM'" -e namespace=NOSUCHITEM
+check_e "invalid -e namespace= argument: 'NOSUCHITEM'" --namespace=NOSUCHITEM
+
 check_h "must have PROG [ARGS] or -p PID" -e decode-pid=all
 check_h "must have PROG [ARGS] or -p PID" --decode-pid=none
 check_h "must have PROG [ARGS] or -p PID" -e decode-pids=comm

--- a/tests/pure_executables.list
+++ b/tests/pure_executables.list
@@ -861,6 +861,7 @@ uname
 unlink
 unlinkat
 unshare
+unshare-report-ns-id
 userfaultfd
 ustat
 utime

--- a/tests/pure_executables.list
+++ b/tests/pure_executables.list
@@ -44,6 +44,7 @@ clone3
 clone3-Xabbrev
 clone3-Xraw
 clone3-Xverbose
+clone3-report-ns-id
 copy_file_range
 creat
 delete_module

--- a/tests/pure_executables.list
+++ b/tests/pure_executables.list
@@ -741,6 +741,7 @@ setgroups
 setgroups32
 sethostname
 setns
+setns-report-ns-id
 setregid
 setregid32
 setresgid

--- a/tests/setns-report-ns-id.c
+++ b/tests/setns-report-ns-id.c
@@ -1,0 +1,48 @@
+/*
+ * Check appending auxstr of setns(2) when --namespace=new is given
+ *
+ * Copyright (c) 2024 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "tests.h"
+#include "scno.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+int
+main(void)
+{
+	skip_if_unavailable("/proc/self/ns/net");
+
+	const char *netns_path = "/proc/self/ns/net";
+	int netns_fd = open(netns_path, O_RDONLY);
+	if (netns_fd < 0)
+		perror_msg_and_skip("open(%s)", netns_path);
+	char netns[PATH_MAX + 1];
+	int n  = readlink(netns_path, netns, sizeof(netns));
+	if (n < 0)
+		perror_msg_and_skip("readlink");
+	else if ((size_t)n >= sizeof(netns))
+		error_msg_and_skip("too large readlink result");
+	netns[n] = '\0';
+
+	if (syscall(__NR_unshare, 0x40000000) < 0)
+		perror_msg_and_skip("unshare (CLONE_NEWNET)");
+
+	int rc = syscall(__NR_setns, netns_fd, 0x40000000);
+	if (rc < 0)
+		perror_msg_and_skip("setns (CLONE_NEWNET)");
+	printf("setns(%d, CLONE_NEWNET) = %s (%s)\n",
+	       netns_fd, sprintrc(rc), netns);
+
+	printf("+++ exited with 0 +++\n");
+
+	return 0;
+}

--- a/tests/unshare-report-ns-id.c
+++ b/tests/unshare-report-ns-id.c
@@ -1,0 +1,2 @@
+#define PRINT_NAMESPACE
+#include "unshare.c"

--- a/tests/unshare.c
+++ b/tests/unshare.c
@@ -11,8 +11,15 @@
 #include "tests.h"
 #include "scno.h"
 
+#include <limits.h>
 #include <stdio.h>
 #include <unistd.h>
+
+#ifdef PRINT_NAMESPACE
+#define LINE_END ""
+#else
+#define LINE_END "\n"
+#endif
 
 int
 main(void)
@@ -23,24 +30,58 @@ main(void)
 	static struct {
 		kernel_ulong_t val;
 		const char *str;
+		const char *fnames[8];
 	} unshare_flags[] = {
-		{ ARG_STR(0) },
+		{ ARG_STR(0), { NULL } },
 		{ 0xdeadcaf5,
 			"CLONE_NEWTIME|CLONE_FS|CLONE_SIGHAND|CLONE_THREAD"
 			"|CLONE_SYSVSEM|CLONE_NEWCGROUP|CLONE_NEWUTS"
-			"|CLONE_NEWIPC|CLONE_NEWUSER|CLONE_NEWNET|0x80a8c075" },
-		{ 0x2000000, "CLONE_NEWCGROUP" },
-		{ ARG_STR(0x81f8f07f) " /* CLONE_??? */" },
+			"|CLONE_NEWIPC|CLONE_NEWUSER|CLONE_NEWNET|0x80a8c075",
+			{ NULL } },
+		{ 0x00000080|0x00020000|0x02000000|0x04000000|0x08000000|0x20000000|0x40000000,
+			"CLONE_NEWTIME|CLONE_NEWNS|CLONE_NEWCGROUP"
+			"|CLONE_NEWUTS|CLONE_NEWIPC|CLONE_NEWPID"
+			"|CLONE_NEWNET",
+			{ "cgroup", "ipc", "mnt", "net", "pid", "time", "uts", NULL } },
+		{ 0x00020000, "CLONE_NEWNS", { "mnt", NULL } },
+		{ 0x2000000, "CLONE_NEWCGROUP", { "cgroup", NULL } },
+		{ 0x10000000, "CLONE_NEWUSER", { "user", NULL } },
+		{ ARG_STR(0x81f8f07f) " /* CLONE_??? */", { NULL } },
 	};
 
 	long rc = syscall(__NR_unshare, bogus_flags);
 	printf("unshare(%#llx /* CLONE_??? */) = %s\n",
 	       (unsigned long long) bogus_flags, sprintrc(rc));
 
+#ifdef PRINT_NAMESPACE
+	if (chdir("/proc/self/ns") != 0)
+		perror_msg_and_skip("chdir");
+#endif
+
 	for (unsigned int i = 0; i < ARRAY_SIZE(unshare_flags); ++i) {
 		rc = syscall(__NR_unshare, unshare_flags[i].val);
-		printf("unshare(%s) = %s\n",
-		       unshare_flags[i].str, sprintrc(rc));
+		printf("unshare(%s) = %s%s",
+		       unshare_flags[i].str, sprintrc(rc), rc == 0? LINE_END: "\n");
+
+#ifdef PRINT_NAMESPACE
+		if (rc == 0) {
+			unsigned int j;
+			for (j = 0; unshare_flags[i].fnames[j]; j++) {
+				char buf[PATH_MAX + 1];
+				int n = readlink(unshare_flags[i].fnames[j], buf, sizeof(buf));
+				if (n < 0)
+					perror_msg_and_skip("readlink");
+				else if ((size_t)n >= sizeof(buf))
+					error_msg_and_skip("too large readlink result");
+				buf[n] = '\0';
+				if (j == 0)
+					printf(" (%s", buf);
+				else
+					printf(", %s", buf);
+			}
+			printf("%s", j == 0? "\n": ")\n");
+		}
+#endif
 	}
 
 	puts("+++ exited with 0 +++");


### PR DESCRIPTION
While analyzing how a container engine works with strace, I want to have a feature printing namespace IDs. The prototype works like this:

```
    $ src/strace -qq -e signal=none -e unshare -e namespace=switch unshare --user --net /bin/true
    unshare(CLONE_NEWUSER|CLONE_NEWNET)     = 0 (net:[4026537408], user:[4026537407])
    $ src/strace -qq -f -e signal=none -e unshare,clone -e namespace=switch \
      		 podman run --rm -ti registry.access.redhat.com/ubi7/ubi:latest /bin/true
    [pid 1089104] clone(child_stack=NULL, flags=CLONE_NEWNS|CLONE_NEWUSER|SIGCHLD) = 1089110 (mnt:[4026531841], user:[4026531837])
    [pid 1089104] clone(child_stack=NULL, flags=CLONE_VM|CLONE_VFORK|SIGCHLD) = 1089111
    ERRO[0000] running `/usr/bin/newuidmap 1089110 0 1000 1 1 100000 65536`: newuidmap: write to uid_map failed: Operation not permitted
    Error: cannot set up namespace using "/usr/bin/newuidmap": exit status 1
```

If this one is an acceptable idea, I want to get the comment about the name of the option: `-e namespace=switch`. 

TODO
- [X] update the --help message
- [X] add a test case for the option syntax
- [X] add a test case for unshare(2)
- [x] add a test case for setns(2)
- [x] add a test case for clone(2)
- [x] add a test case for clone3(2)
- [x] write commit logs in ChangeLog style
- [x] update the man page
- [x] update NEWS
- [x] https://github.com/strace/strace/pull/300#discussion_r1705867809
- [x] https://github.com/strace/strace/pull/300#discussion_r1705871214
- [x] https://github.com/strace/strace/pull/300#discussion_r1705872758
- [x] https://github.com/strace/strace/pull/300#discussion_r1705876137
- [x] https://github.com/strace/strace/pull/300#discussion_r1705877395
- [x] squash some commits