### PR TITLE
ioctl: add spidev ioctl decoding

### DIFF
--- a/bundled/Makefile.am
+++ b/bundled/Makefile.am
@@ -110,6 +110,8 @@ EXTRA_DIST = \
 	linux/include/uapi/linux/smc_diag.h \
 	linux/include/uapi/linux/sock_diag.h \
 	linux/include/uapi/linux/socket.h \
+	linux/include/uapi/linux/spi/spi.h \
+	linux/include/uapi/linux/spi/spidev.h \
 	linux/include/uapi/linux/stat.h \
 	linux/include/uapi/linux/stddef.h \
 	linux/include/uapi/linux/tcp.h \

--- a/bundled/linux/include/uapi/linux/spi/spi.h
+++ b/bundled/linux/include/uapi/linux/spi/spi.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: GPL-2.0+ WITH Linux-syscall-note */
+#ifndef _SPI_H
+#define _SPI_H
+
+#include <linux/const.h>
+
+#define	SPI_CPHA		_BITUL(0)	/* clock phase */
+#define	SPI_CPOL		_BITUL(1)	/* clock polarity */
+
+#define	SPI_MODE_0		(0|0)		/* (original MicroWire) */
+#define	SPI_MODE_1		(0|SPI_CPHA)
+#define	SPI_MODE_2		(SPI_CPOL|0)
+#define	SPI_MODE_3		(SPI_CPOL|SPI_CPHA)
+#define	SPI_MODE_X_MASK		(SPI_CPOL|SPI_CPHA)
+
+#define	SPI_CS_HIGH		_BITUL(2)	/* chipselect active high? */
+#define	SPI_LSB_FIRST		_BITUL(3)	/* per-word bits-on-wire */
+#define	SPI_3WIRE		_BITUL(4)	/* SI/SO signals shared */
+#define	SPI_LOOP		_BITUL(5)	/* loopback mode */
+#define	SPI_NO_CS		_BITUL(6)	/* 1 dev/bus, no chipselect */
+#define	SPI_READY		_BITUL(7)	/* slave pulls low to pause */
+#define	SPI_TX_DUAL		_BITUL(8)	/* transmit with 2 wires */
+#define	SPI_TX_QUAD		_BITUL(9)	/* transmit with 4 wires */
+#define	SPI_RX_DUAL		_BITUL(10)	/* receive with 2 wires */
+#define	SPI_RX_QUAD		_BITUL(11)	/* receive with 4 wires */
+#define	SPI_CS_WORD		_BITUL(12)	/* toggle cs after each word */
+#define	SPI_TX_OCTAL		_BITUL(13)	/* transmit with 8 wires */
+#define	SPI_RX_OCTAL		_BITUL(14)	/* receive with 8 wires */
+#define	SPI_3WIRE_HIZ		_BITUL(15)	/* high impedance turnaround */
+#define	SPI_RX_CPHA_FLIP	_BITUL(16)	/* flip CPHA on Rx only xfer */
+#define SPI_MOSI_IDLE_LOW	_BITUL(17)	/* leave mosi line low when idle */
+
+/*
+ * All the bits defined above should be covered by SPI_MODE_USER_MASK.
+ * The SPI_MODE_USER_MASK has the SPI_MODE_KERNEL_MASK counterpart in
+ * 'include/linux/spi/spi.h'. The bits defined here are from bit 0 upwards
+ * while in SPI_MODE_KERNEL_MASK they are from the other end downwards.
+ * These bits must not overlap. A static assert check should make sure of that.
+ * If adding extra bits, make sure to increase the bit index below as well.
+ */
+#define SPI_MODE_USER_MASK	(_BITUL(18) - 1)
+
+#endif /* _SPI_H */

--- a/bundled/linux/include/uapi/linux/spi/spidev.h
+++ b/bundled/linux/include/uapi/linux/spi/spidev.h
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: GPL-2.0+ WITH Linux-syscall-note */
+/*
+ * include/linux/spi/spidev.h
+ *
+ * Copyright (C) 2006 SWAPP
+ *	Andrea Paterniani <a.paterniani@swapp-eng.it>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+  */
+
+#ifndef SPIDEV_H
+#define SPIDEV_H
+
+#include <linux/types.h>
+#include <linux/ioctl.h>
+#include <linux/spi/spi.h>
+
+/* IOCTL commands */
+
+#define SPI_IOC_MAGIC			'k'
+
+/**
+ * struct spi_ioc_transfer - describes a single SPI transfer
+ * @tx_buf: Holds pointer to userspace buffer with transmit data, or null.
+ *	If no data is provided, zeroes are shifted out.
+ * @rx_buf: Holds pointer to userspace buffer for receive data, or null.
+ * @len: Length of tx and rx buffers, in bytes.
+ * @speed_hz: Temporary override of the device's bitrate.
+ * @bits_per_word: Temporary override of the device's wordsize.
+ * @delay_usecs: If nonzero, how long to delay after the last bit transfer
+ *	before optionally deselecting the device before the next transfer.
+ * @cs_change: True to deselect device before starting the next transfer.
+ * @word_delay_usecs: If nonzero, how long to wait between words within one
+ *	transfer. This property needs explicit support in the SPI controller,
+ *	otherwise it is silently ignored.
+ *
+ * This structure is mapped directly to the kernel spi_transfer structure;
+ * the fields have the same meanings, except of course that the pointers
+ * are in a different address space (and may be of different sizes in some
+ * cases, such as 32-bit i386 userspace over a 64-bit x86_64 kernel).
+ * Zero-initialize the structure, including currently unused fields, to
+ * accommodate potential future updates.
+ *
+ * SPI_IOC_MESSAGE gives userspace the equivalent of kernel spi_sync().
+ * Pass it an array of related transfers, they'll execute together.
+ * Each transfer may be half duplex (either direction) or full duplex.
+ *
+ *	struct spi_ioc_transfer mesg[4];
+ *	...
+ *	status = ioctl(fd, SPI_IOC_MESSAGE(4), mesg);
+ *
+ * So for example one transfer might send a nine bit command (right aligned
+ * in a 16-bit word), the next could read a block of 8-bit data before
+ * terminating that command by temporarily deselecting the chip; the next
+ * could send a different nine bit command (re-selecting the chip), and the
+ * last transfer might write some register values.
+ */
+struct spi_ioc_transfer {
+	__u64		tx_buf;
+	__u64		rx_buf;
+
+	__u32		len;
+	__u32		speed_hz;
+
+	__u16		delay_usecs;
+	__u8		bits_per_word;
+	__u8		cs_change;
+	__u8		tx_nbits;
+	__u8		rx_nbits;
+	__u8		word_delay_usecs;
+	__u8		pad;
+
+	/* If the contents of 'struct spi_ioc_transfer' ever change
+	 * incompatibly, then the ioctl number (currently 0) must change;
+	 * ioctls with constant size fields get a bit more in the way of
+	 * error checking than ones (like this) where that field varies.
+	 *
+	 * NOTE: struct layout is the same in 64bit and 32bit userspace.
+	 */
+};
+
+/* not all platforms use <asm-generic/ioctl.h> or _IOC_TYPECHECK() ... */
+#define SPI_MSGSIZE(N) \
+	((((N)*(sizeof (struct spi_ioc_transfer))) < (1 << _IOC_SIZEBITS)) \
+		? ((N)*(sizeof (struct spi_ioc_transfer))) : 0)
+#define SPI_IOC_MESSAGE(N) _IOW(SPI_IOC_MAGIC, 0, char[SPI_MSGSIZE(N)])
+
+
+/* Read / Write of SPI mode (SPI_MODE_0..SPI_MODE_3) (limited to 8 bits) */
+#define SPI_IOC_RD_MODE			_IOR(SPI_IOC_MAGIC, 1, __u8)
+#define SPI_IOC_WR_MODE			_IOW(SPI_IOC_MAGIC, 1, __u8)
+
+/* Read / Write SPI bit justification */
+#define SPI_IOC_RD_LSB_FIRST		_IOR(SPI_IOC_MAGIC, 2, __u8)
+#define SPI_IOC_WR_LSB_FIRST		_IOW(SPI_IOC_MAGIC, 2, __u8)
+
+/* Read / Write SPI device word length (1..N) */
+#define SPI_IOC_RD_BITS_PER_WORD	_IOR(SPI_IOC_MAGIC, 3, __u8)
+#define SPI_IOC_WR_BITS_PER_WORD	_IOW(SPI_IOC_MAGIC, 3, __u8)
+
+/* Read / Write SPI device default max speed hz */
+#define SPI_IOC_RD_MAX_SPEED_HZ		_IOR(SPI_IOC_MAGIC, 4, __u32)
+#define SPI_IOC_WR_MAX_SPEED_HZ		_IOW(SPI_IOC_MAGIC, 4, __u32)
+
+/* Read / Write of the SPI mode field */
+#define SPI_IOC_RD_MODE32		_IOR(SPI_IOC_MAGIC, 5, __u32)
+#define SPI_IOC_WR_MODE32		_IOW(SPI_IOC_MAGIC, 5, __u32)
+
+
+
+#endif /* SPIDEV_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -347,6 +347,7 @@ libstrace_a_SOURCES =	\
 	socketcall.c \
 	socketutils.c	\
 	sparc.c		\
+	spidev_ioctl.c	\
 	sram_alloc.c	\
 	stage_output.c	\
 	stat.c		\

--- a/src/defs.h
+++ b/src/defs.h
@@ -1455,6 +1455,7 @@ DECL_IOCTL(fs_x);
 DECL_IOCTL(gpio);
 DECL_IOCTL(inotify);
 DECL_IOCTL(kd);
+DECL_IOCTL(spidev);
 DECL_IOCTL(kvm);
 DECL_IOCTL(lirc);
 DECL_IOCTL(nbd);

--- a/src/ioctl.c
+++ b/src/ioctl.c
@@ -291,7 +291,7 @@ ioctl_decode_command_number(struct tcb *tcp, const struct finfo *finfo)
 	case 'k':
 		if (_IOC_DIR(code) == _IOC_WRITE && _IOC_NR(code) == 0) {
 			tprints_arg_begin("SPI_IOC_MESSAGE");
-			PRINT_VAL_U(_IOC_SIZE(code));
+			PRINT_VAL_U((_IOC_SIZE(code) / 32)); // IOC size is sizeof(spi_ioc_transfer) * arg, so divide to get proper arg
 			tprint_arg_end();
 			return 1;
 		}
@@ -377,6 +377,8 @@ ioctl_decode(struct tcb *tcp, const struct finfo *finfo)
 		return evdev_ioctl(tcp, code, arg);
 	case 'I':
 		return inotify_ioctl(tcp, code, arg);
+	case 'k':
+		return spidev_ioctl(tcp, code, arg);
 	case 'K':
 		return kd_ioctl(tcp, code, arg);
 	case 'L':

--- a/src/spidev_ioctl.c
+++ b/src/spidev_ioctl.c
@@ -1,0 +1,184 @@
+#include "defs.h"
+
+#include <linux/spi/spidev.h>
+
+#include "xlat/spi_mode.h"
+
+static int
+spidev_mode_byte(struct tcb *const tcp, const kernel_ulong_t arg)
+{
+    uint8_t val;
+
+    if (entering(tcp))
+        return 0;
+
+    tprint_arg_next();
+    if (umove_or_printaddr(tcp, arg, &val))
+        return RVAL_IOCTL_DECODED;
+
+    printflags(spi_mode, val, "SPI_???");
+
+    return RVAL_IOCTL_DECODED;
+}
+
+static int
+spidev_mode_u32(struct tcb *const tcp, const kernel_ulong_t arg)
+{
+    uint32_t val;
+
+    if (entering(tcp))
+        return 0;
+
+    tprint_arg_next();
+    if (umove_or_printaddr(tcp, arg, &val))
+        return RVAL_IOCTL_DECODED;
+
+    printflags(spi_mode, val, "SPI_???");
+
+    return RVAL_IOCTL_DECODED;
+}
+
+static bool
+print_spi_buf(struct tcb * tcp, kernel_ulong_t buf_k, const char* field_name, unsigned int len)
+{
+    char* local_buf = malloc(len);
+    if (local_buf == NULL) {
+        tprint_unavailable();
+        return false;
+    }
+    tprints_field_name(field_name);
+    if (!umoven_or_printaddr(tcp, buf_k, len, local_buf)) {
+        print_quoted_string(local_buf, len, QUOTE_FORCE_HEX);
+    }
+    tprint_struct_next();
+
+    free(local_buf);
+}
+
+static bool
+print_spi_ioc_transfer(struct tcb * tcp, void *elem_buf, size_t elem_size, void *opaque_data)
+{
+    struct spi_ioc_transfer* elem = (struct spi_ioc_transfer*)elem_buf;
+
+    tprint_struct_begin();
+    if (!print_spi_buf(tcp, elem->tx_buf, "tx_buf", elem->len))
+        return false;
+    if (!print_spi_buf(tcp, elem->rx_buf, "rx_buf", elem->len))
+        return false;
+    PRINT_FIELD_X(*elem, speed_hz);
+	tprint_struct_next();
+    PRINT_FIELD_X(*elem, delay_usecs);
+	tprint_struct_next();
+    PRINT_FIELD_X(*elem, bits_per_word);
+	tprint_struct_next();
+    PRINT_FIELD_X(*elem, cs_change);
+	tprint_struct_next();
+    PRINT_FIELD_X(*elem, tx_nbits);
+	tprint_struct_next();
+    PRINT_FIELD_X(*elem, rx_nbits);
+	tprint_struct_next();
+    PRINT_FIELD_X(*elem, word_delay_usecs);
+	tprint_struct_next();
+    PRINT_FIELD_X(*elem, pad);
+    tprint_struct_end();
+
+    return true;
+}
+
+static int
+spidev_message(struct tcb *const tcp, const kernel_ulong_t arg, int len)
+{
+    if (entering(tcp))
+        return 0;
+
+    tprint_arg_next();
+
+    struct spi_ioc_transfer buf;
+    print_array(tcp, arg, len, &buf, sizeof(buf), tfetch_mem, print_spi_ioc_transfer, NULL);
+
+    return RVAL_IOCTL_DECODED;
+}
+
+static int
+spidev_max_speed_hz(struct tcb *const tcp, const kernel_ulong_t arg)
+{
+    if (entering(tcp))
+        return 0;
+
+    tprint_arg_next();
+
+    uint32_t speed;
+    if (umove_or_printaddr(tcp, arg, &speed))
+        return RVAL_IOCTL_DECODED;
+
+    printnum_ulong(tcp, speed);
+
+    return RVAL_IOCTL_DECODED;
+}
+
+static int
+spidev_bits_per_word(struct tcb *const tcp, const kernel_ulong_t arg)
+{
+    if (entering(tcp))
+        return 0;
+
+    tprint_arg_next();
+
+    uint8_t bpw;
+    if (umove_or_printaddr(tcp, arg, &bpw))
+        return RVAL_IOCTL_DECODED;
+
+    printnum_ulong(tcp, bpw);
+
+    return RVAL_IOCTL_DECODED;
+}
+
+static int
+spidev_lsb_first(struct tcb *const tcp, const kernel_ulong_t arg)
+{
+    if (entering(tcp))
+        return 0;
+
+    tprint_arg_next();
+
+    uint8_t lsb_first;
+    if (umove_or_printaddr(tcp, arg, &lsb_first))
+        return RVAL_IOCTL_DECODED;
+
+    if (lsb_first == 0) {
+        STRACE_PRINTS("MSB_FIRST");
+    } else {
+        STRACE_PRINTS("LSB_FIRST");
+    }
+
+    return RVAL_IOCTL_DECODED;
+}
+
+int
+spidev_ioctl(struct tcb *const tcp, const unsigned int code, const kernel_ulong_t arg)
+{
+    // IOC_MESSAGE
+    if (_IOC_DIR(code) == _IOC_WRITE && _IOC_NR(code) == _IOC_NR(SPI_IOC_MESSAGE(0))) {
+        return spidev_message(tcp, arg, _IOC_SIZE(code) / sizeof(struct spi_ioc_transfer));
+    }
+
+    switch (code) {
+        case SPI_IOC_RD_MODE:
+        case SPI_IOC_WR_MODE:
+            return spidev_mode_byte(tcp, arg);
+        case SPI_IOC_RD_MODE32:
+        case SPI_IOC_WR_MODE32:
+            return spidev_mode_u32(tcp, arg);
+        case SPI_IOC_RD_LSB_FIRST:
+        case SPI_IOC_WR_LSB_FIRST:
+            return spidev_lsb_first(tcp, arg);
+        case SPI_IOC_RD_BITS_PER_WORD:
+        case SPI_IOC_WR_BITS_PER_WORD:
+            return spidev_bits_per_word(tcp, arg);
+        case SPI_IOC_RD_MAX_SPEED_HZ:
+        case SPI_IOC_WR_MAX_SPEED_HZ:
+            return spidev_max_speed_hz(tcp, arg);
+    }
+
+	return RVAL_DECODED;
+}

--- a/src/xlat/spi_mode.in
+++ b/src/xlat/spi_mode.in
@@ -1,0 +1,2 @@
+SPI_CPHA (1 << 0)
+SPI_CPOL (1 << 1)


### PR DESCRIPTION
I was doing some light SPI reverse engineering and this came in handy. 

The contributing page says everything must happen via the mailing list, but this seems to not be the case as PR's have been merged in the past....I'm happy to re-send there though. 