### PR TITLE
ioctl: Hex-dump arg buffer for unknown ioctls

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ Noteworthy changes in release ?.?? (????-??-??)
   * Implemented decoding of uretprobe syscall.
   * Implemented decoding of WDIOC_GETSUPPORT and WDIOC_SETOPTIONS ioctl
     commands.
+  * Enhanced decoding of unknown ioctl commands in non-abbreviated mode
+    by printing the contents of the ioctl argument buffer in hexadecimal format.
   * Updated decoding of listmount, statmount, and statx syscalls.
   * Updated lists of ETHTOOL_*, IORING_*, IPPROTO_*, RWF_*, STATX_*, and V4L2_*
     constants.

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -270,6 +270,7 @@ io_uring_register-success-Xraw
 io_uring_register-success-Xverbose
 io_uring_setup
 ioctl
+ioctl-v
 ioctl_block
 ioctl_block--pidns-translation
 ioctl_counter

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -293,6 +293,7 @@ io_uring_register-success-Xabbrev	-einject=io_uring_register:retval=42 -etrace=i
 io_uring_register-success-Xraw		-einject=io_uring_register:retval=42 -etrace=io_uring_register -y -Xraw
 io_uring_register-success-Xverbose	-einject=io_uring_register:retval=42 -etrace=io_uring_register -y -Xverbose
 io_uring_setup	-a26 -y
+ioctl-v	+ioctl.test -v
 ioctl_block	+ioctl.test
 ioctl_counter	+ioctl.test -a39
 ioctl_counter-Xabbrev	+ioctl.test -a39 -Xabbrev

--- a/tests/ioctl-v.c
+++ b/tests/ioctl-v.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015-2024 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "tests.h"
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+int
+main(void)
+{
+	uint8_t array[8] = { 0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef };
+	char array_str[] = "\\xfe\\xed\\xfa\\xce\\xde\\xad\\xbe\\xef";
+
+	/* Zero-length read */
+	(void) ioctl(-1, _IOC(_IOC_READ, 0xde, 0x0, 0), (kernel_ulong_t) -1ULL);
+	printf("ioctl(-1, _IOC(_IOC_READ, 0xde, 0, 0), %#lx)"
+	       RVAL_EBADF, -1UL);
+
+	/* Zero-length write */
+	(void) ioctl(-1, _IOC(_IOC_WRITE, 0xde, 0, 0), (kernel_ulong_t) -1ULL);
+	printf("ioctl(-1, _IOC(_IOC_WRITE, 0xde, 0, 0), %#lx)"
+	       RVAL_EBADF, -1UL);
+
+	/* Data read from ioctl */
+	(void) ioctl(-1, _IOR(0xde, 0xad, array), array);
+	printf("ioctl(-1, _IOC(_IOC_READ, 0xde, 0xad, 0x8), \"%s\")"
+	       RVAL_EBADF, array_str);
+
+	/* Data written to ioctl */
+	(void) ioctl(-1, _IOW(0xde, 0xad, array), array);
+	printf("ioctl(-1, _IOC(_IOC_WRITE, 0xde, 0xad, 0x8), \"%s\")"
+	       RVAL_EBADF, array_str);
+
+	/* Bi-directional data movement */
+	(void) ioctl(-1, _IOWR(0xde, 0xad, array), array);
+	printf("ioctl(-1, _IOC(_IOC_READ|_IOC_WRITE, 0xde, 0xad, 0x8)"
+	       ", \"%s\" => \"%s\")"
+	       RVAL_EBADF, array_str, array_str);
+
+	/* Neither read nor write implied by ioctl, but valid arg provided */
+	(void) ioctl(-1, _IOC(_IOC_NONE, 0xde, 0xad, sizeof(array)), array);
+	printf("ioctl(-1, _IOC(_IOC_NONE, 0xde, 0xad, 0x8), \"%s\" => \"%s\")"
+	       RVAL_EBADF, array_str, array_str);
+
+	/* Arg expected for ioctl, but arg pointer is bad */
+	(void) ioctl(-1, _IOC(_IOC_NONE, 0xde, 0, 8), (kernel_ulong_t) -1ULL);
+	printf("ioctl(-1, _IOC(_IOC_NONE, 0xde, 0, 0x8), %#lx)"
+	       RVAL_EBADF, -1UL);
+
+	puts("+++ exited with 0 +++");
+	return 0;
+}

--- a/tests/pure_executables.list
+++ b/tests/pure_executables.list
@@ -202,6 +202,7 @@ io_uring_register-Xraw
 io_uring_register-Xverbose
 io_uring_setup
 ioctl
+ioctl-v
 ioctl_block
 ioctl_counter
 ioctl_counter-Xabbrev


### PR DESCRIPTION
This change adds the ability to print the payload of ioctls that aren't explicitly supported by strace, provided that the ioctl number follows modern Linux conventions.

Example output: (cherry-picked test output from tests/ioctl.c)

```
ioctl(-1, MMTIMER_GETRES, "\x00\x00\x00\x00\x00\x00\x00\x00") = -1 EBADF (Bad file descriptor)
ioctl(-1, VIDIOC_ENUMINPUT, NULL) = -1 EBADF (Bad file descriptor)
ioctl(-1, HIDIOCGRDESCSIZE or HIDIOCGVERSION, "\x00\x00\x00\x00") = -1 EBADF (Bad file descriptor)
ioctl(-1, _IOC(_IOC_READ, 0xde, 0xad, 0x8), "\xfe\xed\xfa\xce\xde\xad\xbe\xef") = -1 EBADF (Bad file descriptor)
ioctl(-1, _IOC(_IOC_WRITE, 0xde, 0xad, 0x8), "\xfe\xed\xfa\xce\xde\xad\xbe\xef") = -1 EBADF (Bad file descriptor)
ioctl(-1, _IOC(_IOC_READ|_IOC_WRITE, 0xde, 0xad, 0x8), "\xfe\xed\xfa\xce\xde\xad\xbe\xef" => "\xfe\xed\xfa\xce\xde\xad\xbe\xef") = -1 EBADF (Bad file descriptor)
ioctl(-1, _IOC(_IOC_NONE, 0xde, 0xad, 0x8), "\xfe\xed\xfa\xce\xde\xad\xbe\xef" => "\xfe\xed\xfa\xce\xde\xad\xbe\xef") = -1 EBADF (Bad file descriptor)
ioctl(-1, _IOC(_IOC_NONE, 0xde, 0, 0x8), 0xffffffffffffffff) = -1 EBADF (Bad file descriptor)
```

Test results:

```
============================================================================
Testsuite summary for strace 6.9.0.44.7c93
============================================================================
# TOTAL: 1355
# PASS:  1254
# SKIP:  101
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

Thanks for considering this PR.  Please let me know if you have any questions or concerns.