### PR TITLE
print_utils.h: initialize `hex_chars` as an array, not via string

### DIFF
--- a/src/print_utils.h
+++ b/src/print_utils.h
@@ -12,8 +12,13 @@
 # include <inttypes.h>
 
 /* Hexadecimal output utils */
-
-static const char hex_chars[16] = "0123456789abcdef";
+static const char hex_chars[16] = {
+	/* Did not use "0123456789abcdef" as an initializer directly as
+	 * gcc-15 warns about the truncation:
+	 *   https://gcc.gnu.org/PR115185 */
+	'0', '1', '2', '3', '4', '5', '6', '7',
+	'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+};
 
 /**
  * Character array representing hexadecimal encoding of a character value.


### PR DESCRIPTION
`gcc-15` added a new warning in https://gcc.gnu.org/PR115185:

    print_utils.h:16:35: error: initializer-string for array of 'char' is too long [-Werror=unterminated-string-initialization]
       16 | static const char hex_chars[16] = "0123456789abcdef";
          |                                   ^~~~~~~~~~~~~~~~~~

`strace` does not need to store '\0'. We could either initialize the arrays with individual bytes or allocate extra byte for null.

This change initializes the array bytewise.