### PR TITLE
sched_attr: Define conditionally on SCHED_ATTR_SIZE_VER1

### DIFF
--- a/src/sched_attr.h
+++ b/src/sched_attr.h
@@ -11,6 +11,9 @@
 
 # include <stdint.h>
 
+# define SCHED_ATTR_MIN_SIZE	48
+
+# ifndef SCHED_ATTR_SIZE_VER1
 struct sched_attr {
 	uint32_t size;
 	uint32_t sched_policy;
@@ -24,10 +27,7 @@ struct sched_attr {
 	uint32_t sched_util_min;
 	uint32_t sched_util_max;
 };
-
-# define SCHED_ATTR_MIN_SIZE	48
-# ifndef SCHED_ATTR_SIZE_VER1
 #  define SCHED_ATTR_SIZE_VER1  56
-# endif
+# endif /* SCHED_ATTR_SIZE_VER1 */
 
 #endif /* !STRACE_SCHED_ATTR_H */


### PR DESCRIPTION
glibc 2.41+ has added [1] definitions for sched_setattr and sched_getattr functions and struct sched_attr. Therefore, it needs to be checked for here as well before defining sched_attr

Fixes builds with glibc/trunk

In file included from ../../strace-6.11/src/sched.c:14: ../../strace-6.11/src/sched_attr.h:16:8: error: redefinition of 'sched_attr'
   16 | struct sched_attr {
      |        ^
/mnt/b/yoe/master/build/tmp/work/core2-64-yoe-linux/strace/6.11/recipe-sysroot/usr/include/linux/sched/types.h:98:8: note: previous definition is here
   98 | struct sched_attr {
      |        ^

[1] https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=21571ca0d70302909cf72707b2a7736cf12190a0;hp=298bc488fdc047da37482f4003023cb9adef78f8
Signed-off-by: Khem Raj <raj.khem@gmail.com>