### PR TITLE
tests: Skip legacy_syscall_info on riscv64 with kernel 6.11+

### DIFF
--- a/tests/init.sh
+++ b/tests/init.sh
@@ -382,6 +382,17 @@ require_min_kernel_version_or_skip()
 		skip_ "the kernel release $uname_r is not $1 or newer"
 }
 
+# Usage: require_max_kernel_version_or_skip 6.11
+require_max_kernel_version_or_skip()
+{
+	local uname_r
+	uname_r="$(uname -r)"
+
+	[ "$(kernel_version_code "$uname_r")" -lt \
+	  "$(kernel_version_code "$1")" ] ||
+		skip_ "the kernel release $uname_r is $1 or newer"
+}
+
 # Usage: require_min_nproc 2
 require_min_nproc()
 {

--- a/tests/legacy_syscall_info.test
+++ b/tests/legacy_syscall_info.test
@@ -10,6 +10,11 @@
 
 . "${srcdir=.}/init.sh"
 
+# The legacy API is broken on riscv64 with kernel 6.11+
+# https://github.com/strace/strace/issues/315
+[ "$(uname -m)" != "riscv64" ] ||
+    require_max_kernel_version_or_skip 6.11
+
 check_prog grep
 $STRACE -d -enone / > /dev/null 2> "$LOG" ||:
 grep -x "[^:]*strace: PTRACE_GET_SYSCALL_INFO works" "$LOG" > /dev/null ||


### PR DESCRIPTION
Kernel commit [61119394631f219e](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=61119394631f219e23ce98bcc3eb993a64a8ea64) ("riscv: entry: always initialize regs->a0 to -ENOSYS") made the legacy API unusable for us, which means that the test always fails when using a recent kernel.

Closes: https://github.com/strace/strace/issues/315