### PR TITLE
secontext: fixed retrieval of symlink context and /proc/self/ handling

### DIFF
--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -739,11 +739,11 @@ open--secontext_full_mismatch	-a30 -P open.sample --secontext=full,mismatch --tr
 open--secontext_mismatch		-a30 -P open.sample --secontext=mismatch --trace=open
 open_tree -a30 -y
 open_tree-P -a30 --decode-fds -P /dev/full -e trace=open_tree
-openat	-a36 -P $NAME.sample
-openat--secontext	-a36 -P openat.sample -P $PWD/openat.sample --secontext -e trace=openat
-openat--secontext_full	-a36 -P openat.sample -P $PWD/openat.sample --secontext=full -e trace=openat
-openat--secontext_full_mismatch	-a36 -P openat.sample -P $PWD/openat.sample --secontext=full,mismatch -e trace=openat
-openat--secontext_mismatch	-a36 -P openat.sample -P $PWD/openat.sample --secontext=mismatch -e trace=openat
+openat	-a36 -P openat.sample -P /proc/self/fd/0 -P ./proc/self/openat.sample
+openat--secontext	-a36 -P openat.sample -P /proc/self/fd/0 -P ./proc/self/openat.sample --secontext -e trace=openat
+openat--secontext_full	-a36 -P openat.sample -P /proc/self/fd/0 -P ./proc/self/openat.sample --secontext=full -e trace=openat
+openat--secontext_full_mismatch	-a36 -P openat.sample -P /proc/self/fd/0 -P ./proc/self/openat.sample --secontext=full,mismatch -e trace=openat
+openat--secontext_mismatch	-a36 -P openat.sample -P /proc/self/fd/0 -P ./proc/self/openat.sample --secontext=mismatch -e trace=openat
 openat2	-a35
 openat2-Xabbrev	--trace=openat2 -a35 -Xabbrev
 openat2-Xraw	--trace=openat2 -a32 -Xraw

--- a/tests/openat.c
+++ b/tests/openat.c
@@ -14,6 +14,8 @@
 # include <asm/fcntl.h>
 # include <stdio.h>
 # include <unistd.h>
+# include <limits.h>
+# include <sys/stat.h>
 
 # include "secontext.h"
 
@@ -25,6 +27,7 @@
 # endif
 
 static const char sample[] = "openat.sample";
+static const char self_fd0[] = "/proc/self/fd/0";
 
 static void
 test_mode_flag(unsigned int mode_val, const char *mode_str,
@@ -160,6 +163,60 @@ main(void)
 		if (unlink(sample))
 			perror_msg_and_fail("unlink");
 	}
+
+	char buf[PATH_MAX];
+	if (readlink(self_fd0, buf, sizeof(buf) - 1) > 0) {
+		char *self_fd0_secontext = SECONTEXT_FILE(self_fd0);
+		char *target_secontext = SECONTEXT_FILE(buf);
+
+		fd = syscall(__NR_openat, cwd_fd, self_fd0, O_RDONLY);
+		printf("%s%s(%d%s, \"%s\"%s, O_RDONLY) = %s%s\n",
+		       my_secontext, "openat",
+		       cwd_fd, cwd_secontext,
+		       self_fd0, self_fd0_secontext,
+		       sprintrc(fd), target_secontext);
+		if (fd != -1)
+			close(fd);
+	}
+
+	/* Check "fake" /proc/self */
+
+	if (mkdir("./proc", 0700) || mkdir("./proc/self", 0700))
+		perror_msg_and_fail("mkdir");
+
+	snprintf(buf, sizeof(buf), "./proc/self/%s", sample);
+
+	fd = syscall(__NR_openat, cwd_fd, buf, O_RDONLY|O_CREAT, 0400);
+	if (fd == -1)
+		perror_msg_and_fail("openat");
+	close(fd);
+
+	sample_secontext = SECONTEXT_FILE(buf);
+
+	/*
+	 * File context in openat() is not displayed because file doesn't exist
+	 * yet, but is displayed in return value since the file got created.
+	 */
+	printf("%s%s(%d%s, \"%s\", O_RDONLY|O_CREAT, 0400) = %s%s\n",
+	       my_secontext, "openat",
+	       cwd_fd, cwd_secontext,
+	       buf,
+	       sprintrc(fd), sample_secontext);
+
+	fd = syscall(__NR_openat, cwd_fd, buf, O_RDONLY);
+	printf("%s%s(%d%s, \"%s\"%s, O_RDONLY) = %s%s\n",
+	       my_secontext, "openat",
+	       cwd_fd, cwd_secontext,
+	       buf, sample_secontext,
+	       sprintrc(fd), sample_secontext);
+	if (fd != -1) {
+		close(fd);
+		if (unlink(buf))
+			perror_msg_and_fail("unlink");
+	}
+
+	rmdir("./proc/self");
+	rmdir("./proc");
 
 	leave_and_remove_subdir();
 

--- a/tests/secontext.c
+++ b/tests/secontext.c
@@ -11,6 +11,9 @@
 
 # include <assert.h>
 # include <errno.h>
+# include <libgen.h>
+# include <limits.h>
+# include <stdio.h>
 # include <stdlib.h>
 # include <string.h>
 # include <sys/stat.h>
@@ -22,6 +25,8 @@
 
 # define TEST_SECONTEXT
 # include "secontext.h"
+
+static char unknown_expected_context[] = "??";
 
 ATTRIBUTE_FORMAT((printf, 2, 0)) ATTRIBUTE_MALLOC
 static char *
@@ -86,7 +91,7 @@ static char *
 raw_expected_secontext_full_file(const char *filename)
 {
 	int saved_errno = errno;
-	char *secontext;
+	char *secontext = NULL;
 
 	static struct selabel_handle *hdl;
 	if (!hdl) {
@@ -95,20 +100,37 @@ raw_expected_secontext_full_file(const char *filename)
 			perror_msg_and_skip("selabel_open");
 	}
 
-	char *resolved = realpath(filename, NULL);
-	if (!resolved)
-		perror_msg_and_fail("realpath: %s", filename);
-
 	struct stat statbuf;
-	if (stat(resolved, &statbuf) < 0)
-		perror_msg_and_fail("stat: %s", resolved);
+	if (lstat(filename, &statbuf) < 0)
+		perror_msg_and_fail("stat: %s", filename);
 
-	if (selabel_lookup(hdl, &secontext, resolved, statbuf.st_mode) < 0)
-		perror_msg_and_skip("selabel_lookup: %s", resolved);
-	free(resolved);
+	char buf[PATH_MAX + 1];
+
+	if (S_ISLNK(statbuf.st_mode)) {
+		char bufb[PATH_MAX + 1];
+		strcpy(buf, filename);
+		strcpy(bufb, filename);
+		char *d = dirname(buf);
+		char *resolved = realpath(d, NULL);
+		if (!resolved)
+			perror_msg_and_fail("realpath: %s", filename);
+		char *b = basename(bufb);
+		snprintf(buf, sizeof(buf), "%s/%s", resolved, b);
+		free(resolved);
+	} else {
+		char *resolved = realpath(filename, NULL);
+		if (!resolved)
+			perror_msg_and_fail("realpath: %s", filename);
+		strcpy(buf, resolved);
+		free(resolved);
+	}
+
+	if ((selabel_lookup(hdl, &secontext, buf, statbuf.st_mode) < 0) && (errno != ENOENT))
+		secontext = unknown_expected_context;
 
 	char *full_secontext = xstrdup(secontext);
-	freecon(secontext);
+	if (secontext != unknown_expected_context)
+		freecon(secontext);
 	errno = saved_errno;
 	return full_secontext;
 }
@@ -133,7 +155,7 @@ raw_secontext_full_file(const char *filename)
 	char *full_secontext = NULL;
 	char *secontext;
 
-	if (getfilecon(filename, &secontext) >= 0) {
+	if (lgetfilecon(filename, &secontext) >= 0) {
 		full_secontext = strip_trailing_newlines(xstrdup(secontext));
 		freecon(secontext);
 	}


### PR DESCRIPTION
There were multiple issues with symlink handling.

1. When the path being queried is a symlink, we expect the context of the symlink to be displayed, not the one of the target. Due to this, lgetfilecon() has to be used instead of getfilecon() in selinux_getfilecon().  For selinux_getfdcon(), this doesn't apply because we cannot query a symlink.

2. When in 'mismatch' mode, querying the expected context for symlinks becomes harder, because realpath() cannot be used, since it would resolve the symlink, hence the query would end up on the target instead of the symlink itself. To solve this, only the dirname of the path is resolved.

3. SELinux context queries are performed through prefixing by /proc/<PID>/{root,cwd,fd/<FD>}/. This led to querying strace's namespace instead of PID's namespace when resolving paths such as /proc/self/something, because /proc/self always points to ourselves (hence strace). Because of this /proc/self must be substituted as /proc/<PID> first, but this may not always work, because there could be a "fake" /proc/self" in the path. To solve this, the context query is performed on the substituted path and if there is no result, the original path is queried as fallback.

4. Unrelated to symlinks, there was no distinction between not being able to retrieve the expected context due to some error and not having any known expected context. To solve this, on error, a "??" static context is returned.