### PR TITLE
v4l2: decode `VIDIOC_EXPBUF`

### DIFF
--- a/src/v4l2.c
+++ b/src/v4l2.c
@@ -488,6 +488,39 @@ print_v4l2_requestbuffers(struct tcb *const tcp, const kernel_ulong_t arg)
 	return RVAL_IOCTL_DECODED;
 }
 
+static int
+print_v4l2_exportbuffer(struct tcb *const tcp, const kernel_ulong_t arg)
+{
+	struct v4l2_exportbuffer expbuf;
+
+	if (entering(tcp)) {
+		tprint_arg_next();
+		if (umove_or_printaddr(tcp, arg, &expbuf))
+			return RVAL_IOCTL_DECODED;
+
+		tprint_struct_begin();
+		PRINT_FIELD_XVAL(expbuf, type, v4l2_buf_types,
+				 "V4L2_BUF_TYPE_???");
+		tprint_struct_next();
+		PRINT_FIELD_U(expbuf, index);
+		tprint_struct_next();
+		PRINT_FIELD_U(expbuf, plane);
+		tprint_struct_next();
+		PRINT_FIELD_OBJ_VAL(expbuf, flags, tprint_open_modes);
+
+		return 0;
+	}
+
+	if (!syserror(tcp) && !umove(tcp, arg, &expbuf)) {
+		tprint_struct_end_value_changed_struct_begin();
+		PRINT_FIELD_FD(expbuf, fd, tcp);
+	}
+
+	tprint_struct_end();
+
+	return RVAL_IOCTL_DECODED;
+}
+
 #include "xlat/v4l2_buf_flags.h"
 #include "xlat/v4l2_buf_flags_ts_type.h"
 #include "xlat/v4l2_buf_flags_ts_src.h"
@@ -1527,6 +1560,9 @@ MPERS_PRINTER_DECL(int, v4l2_ioctl, struct tcb *const tcp,
 
 	case VIDIOC_REQBUFS: /* RW */
 		return print_v4l2_requestbuffers(tcp, arg);
+
+	case VIDIOC_EXPBUF: /* RW */
+		return print_v4l2_exportbuffer(tcp, arg);
 
 	case VIDIOC_QUERYBUF: /* RW */
 	case VIDIOC_QBUF: /* RW */

--- a/tests/ioctl_v4l2.c
+++ b/tests/ioctl_v4l2.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include "kernel_fcntl.h"
 #include "kernel_v4l2_types.h"
 
 #define cc0(arg) ((unsigned int) (unsigned char) (arg))
@@ -499,7 +500,6 @@ main(void)
 		const char *str;
 	} unsupp_cmds[] = {
 		{ ARG_STR(VIDIOC_OVERLAY) },
-		{ ARG_STR(VIDIOC_EXPBUF) },
 		{ ARG_STR(VIDIOC_G_AUDIO) },
 		{ ARG_STR(VIDIOC_S_AUDIO) },
 		{ ARG_STR(VIDIOC_QUERYMENU) },
@@ -1333,6 +1333,31 @@ main(void)
 #endif
 	       "})" RVAL_EBADF,
 	       XLAT_STR(VIDIOC_QUERY_EXT_CTRL));
+
+	ioctl(-1, VIDIOC_EXPBUF, 0);
+	printf("ioctl(-1, %s, NULL)" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_EXPBUF));
+
+	TAIL_ALLOC_OBJECT_CONST_PTR(struct v4l2_exportbuffer, p_v4l2_expbuf);
+
+	p_v4l2_expbuf->type = -1;
+	p_v4l2_expbuf->index = 123;
+	p_v4l2_expbuf->plane = 321;
+	p_v4l2_expbuf->flags = O_RDONLY | O_CLOEXEC;
+
+	ioctl(-1, VIDIOC_EXPBUF, p_v4l2_expbuf);
+	printf("ioctl(-1, %s, {"
+	       "type=%#x" NRAW(" /* V4L2_BUF_TYPE_??? */") ", "
+	       "index=%u, "
+	       "plane=%u, "
+	       "flags=" NABBR("%#x") VERB(" /* ") NRAW("O_RDONLY|O_CLOEXEC") VERB(" */")
+	       "})" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_EXPBUF),
+	       p_v4l2_expbuf->type,
+	       p_v4l2_expbuf->index,
+	       p_v4l2_expbuf->plane
+	       NABBR(, p_v4l2_expbuf->flags)
+	);
 
 	puts("+++ exited with 0 +++");
 	return 0;


### PR DESCRIPTION
```
Decode the `VIDIOC_EXPBUF` v4l2 ioctl as follows:

  ioctl(17</dev/video10>,
        VIDIOC_EXPBUF,
        {type=V4L2_BUF_TYPE_VIDEO_CAPTURE, index=2, plane=0, flags=O_RDWR|O_CLOEXEC}
          => {fd=25</dmabuf:>}) = 0 <0.000091>

Every current field is supported, the `fd` field is decoded on return.

* src/v4l2.c: Decode `VIDIOC_EXPBUF`.
* tests/ioctl_v4l2.c: Remove `VIDIOC_EXPBUF` from list of unsupported ioctls, and add some `VIDIOC_EXPBUF` tests.
```

PS: I couldn't subscribe to the mailing list, so here it is.