### PR TITLE
tests: use .code16 to express kvm input directly in real-mode

### DIFF
--- a/tests/ioctl_kvm_run_common.c
+++ b/tests/ioctl_kvm_run_common.c
@@ -73,12 +73,19 @@ extern const char code[];
 extern const unsigned short code_size;
 
 __asm__(
+	/* The VM is in real mode. */
+	".code16			\n"
 	".type code, @object		\n"
 	"code:				\n"
-	"	mov $0xd80003f8, %edx	\n"
-	"	mov $'\n', %al		\n"
+	"	mov $0x03f8, %dx	\n"
+	"	movb $'\n', %al		\n"
 	"	out %al, (%dx)		\n"
 	"	hlt			\n"
+# ifdef __x86_64__
+	".code64			\n"
+# else
+	".code32			\n"
+# endif
 	".size code, . - code		\n"
 	".type code_size, @object	\n"
 	"code_size:			\n"


### PR DESCRIPTION
* tests/ioctl_kvm_run_common.c (top-level): Use .code16 int the inline assembly code. Rewrite the code in real-mode notation.