### PR TITLE
kvm: decode kvm_run.{immediate_exit,flags} conditionally

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -553,6 +553,11 @@ AC_CHECK_TYPES(m4_normalize([
 	struct kvm_userspace_memory_region
 ]),,, [#include <linux/kvm.h>])
 
+AC_CHECK_MEMBERS(m4_normalize([
+	struct kvm_run.immediate_exit,
+	struct kvm_run.flags
+]),,, [#include <linux/kvm.h>])
+
 AC_CHECK_TYPES(m4_normalize([
 	struct sockaddr_alg_new
 ]),,, [#include <netinet/in.h>

--- a/src/kvm.c
+++ b/src/kvm.c
@@ -495,8 +495,10 @@ kvm_run_structure_decode_main(struct tcb *tcp,
 
 	PRINT_FIELD_U(*state, request_interrupt_window);
 	tprint_struct_next();
+# ifdef HAVE_STRUCT_KVM_RUN_IMMEDIATE_EXIT
 	PRINT_FIELD_U(*state, immediate_exit);
 	tprint_struct_next();
+# endif
 
 	PRINT_FIELD_U(*state, exit_reason);
 	if (auxstr)
@@ -506,8 +508,10 @@ kvm_run_structure_decode_main(struct tcb *tcp,
 	tprint_struct_next();
 	PRINT_FIELD_U(*state, if_flag);
 	tprint_struct_next();
+# ifdef	HAVE_STRUCT_KVM_RUN_FLAGS
 	PRINT_FIELD_X(*state, flags);
 	tprint_struct_next();
+# endif
 
 	PRINT_FIELD_0X(*state, cr8);
 	tprint_struct_next();

--- a/tests/ioctl_kvm_run_auxstr_vcpu_more.c
+++ b/tests/ioctl_kvm_run_auxstr_vcpu_more.c
@@ -12,12 +12,26 @@
 static void
 print_kvm_run_more(const char *prefix, const char *reason_str, const struct kvm_run *run)
 {
-	printf(" %s {request_interrupt_window=%u, immediate_exit=%u"
+	printf(" %s {request_interrupt_window=%u"
+# ifdef HAVE_STRUCT_KVM_RUN_IMMEDIATE_EXIT
+	       ", immediate_exit=%u"
+# endif
 	       ", exit_reason=%d /* %s */, ready_for_interrupt_injection=%u"
-	       ", if_flag=%u, flags=%u, cr8=%#016llx, apic_base=%#016llx",
-	       prefix, run->request_interrupt_window, run->immediate_exit,
+	       ", if_flag=%u"
+# ifdef HAVE_STRUCT_KVM_RUN_FLAGS
+	       ", flags=%u"
+# endif
+	       ", cr8=%#016llx, apic_base=%#016llx",
+	       prefix, run->request_interrupt_window,
+# ifdef HAVE_STRUCT_KVM_RUN_IMMEDIATE_EXIT
+	       run->immediate_exit,
+# endif
 	       run->exit_reason, reason_str, run->ready_for_interrupt_injection,
-	       run->if_flag, run->flags, run->cr8, run->apic_base);
+	       run->if_flag,
+# ifdef HAVE_STRUCT_KVM_RUN_FLAGS
+	       run->flags,
+# endif
+	       run->cr8, run->apic_base);
 
 	switch (run->exit_reason) {
 	case KVM_EXIT_IO:


### PR DESCRIPTION
struct kvm_run.immediate_exit was introduced by linux kernel commit v4.11-rc1~109^2~15, and struct kvm_run.flags was introduced by linux kernel commit v4.2-rc1~134^2~41.

* configure (AC_CHECK_MEMBERS): Add kvm_run.immediate_exit and struct kvm_run.flags.
* src/kvm.c (kvm_run_structure_decode_main): Decode kvm_run.immediate_exit only if HAVE_STRUCT_KVM_RUN_IMMEDIATE_EXIT is defined. Decode struct kvm_run.flags only if HAVE_STRUCT_KVM_RUN_FLAGS is defined.
* tests/ioctl_kvm_run_auxstr_vcpu_more.c (print_kvm_run_more): Print these members only when the corresponding macros are defined.

Resolves: https://github.com/strace/strace/issues/359