### PR TITLE
kvm: decode data written to and read from I/O ports

### DIFF
--- a/tests/ioctl_kvm_run_auxstr_vcpu_more.c
+++ b/tests/ioctl_kvm_run_auxstr_vcpu_more.c
@@ -36,11 +36,16 @@ print_kvm_run_more(const char *prefix, const char *reason_str, const struct kvm_
 	switch (run->exit_reason) {
 	case KVM_EXIT_IO:
 		printf(", {io={direction=%s"
-		       ", size=%u, port=%#04x, count=%u, data_offset=%#016llx}}",
+		       ", size=%u, port=%#04x, count=%u, data_offset=%#016llx",
 		       run->io.direction == KVM_EXIT_IO_IN
 		       ? "KVM_EXIT_IO_IN" : "KVM_EXIT_IO_OUT",
 		       run->io.size, run->io.port,
 		       run->io.count, run->io.data_offset);
+		fputs(", data=[", stdout);
+		for (unsigned long i = 0; i < (run->io.size * run->io.count); ++i)
+			printf("%s%#x", i == 0?  "" : ", ",
+			       ((unsigned char *)run + run->io.data_offset)[i]);
+		fputs("]}}", stdout);
 		break;
 	case KVM_EXIT_MMIO:
 		printf(", {mmio={phys_addr=%#016llx"

--- a/tests/ioctl_kvm_run_common.c
+++ b/tests/ioctl_kvm_run_common.c
@@ -226,10 +226,11 @@ run_kvm(const int vcpu_fd, struct kvm_run *const run, const size_t mmap_size,
 	const char *p = "\n";
 
 	/* Repeatedly run code and handle VM exits. */
+	struct kvm_run *run_before = tail_alloc(mmap_size);
 	for (;;) {
-		const struct kvm_run run_before = *run;
+		memcpy(run_before, run, mmap_size);
 		KVM_IOCTL(vcpu_fd, KVM_RUN, NULL);
-		print_KVM_RUN(vcpu_fd, vcpu_dev, &run_before, run);
+		print_KVM_RUN(vcpu_fd, vcpu_dev, run_before, run);
 
 		switch (run->exit_reason) {
 		case KVM_EXIT_HLT:


### PR DESCRIPTION
With the "-e kvm=vcpu+" option, strace now decodes data written to and read from I/O ports.

* src/kvm.c (kvm_run_structure_decode_io): Decode data written to or read from I/O ports as a byte array.
(kvm_run_structure_decode_main): Add struct vcpu_info as a new parameter and pass it down to kvm_run_structure_decode_io(). (kvm_run_structure_decode): Pass a struct vcpu_info object to kvm_run_structure_decode_main.
* tests/ioctl_kvm_run_common.c (run_kvm): Allocate buffer for run_before dynamically and copy entire mmap'ed region to the buffer.
* tests/ioctl_kvm_run_auxstr_vcpu_more.c (print_kvm_run_more): Print data written to or read from I/O ports.