### PR TITLE
tests: Skip legacy_syscall_info on riscv64 with kernel 6.6.49+ too

### DIFF
--- a/tests/legacy_syscall_info.test
+++ b/tests/legacy_syscall_info.test
@@ -12,9 +12,10 @@
 . "${srcdir=.}/init.sh"
 
 # The legacy API is broken on riscv64 with kernel 6.11+
+# The same change was also backported into the 6.6 stable tree
 # https://github.com/strace/strace/issues/315
 [ "$(uname -m)" != "riscv64" ] ||
-    require_max_kernel_version_or_skip 6.11
+    require_max_kernel_version_or_skip 6.6.49
 
 check_prog grep
 $STRACE -d -enone / > /dev/null 2> "$LOG" ||:


### PR DESCRIPTION
Follow-up to #330. See #315 for background.

---

Back in late 2024, strace commit ba41bc0da4b841d9 made it so that this test is skipped when running on kernel 6.11+, which is the first release containing kernel commit [61119394631f219e](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=61119394631f219e23ce98bcc3eb993a64a8ea64) ("riscv: entry: always initialize regs->a0 to -ENOSYS"), the one that broke the legacy API on riscv64.

What I failed to realize at the time is that the change had also been backported to the 6.6 tree as kernel commit [84557cd61182edf7](https://github.com/gregkh/linux/commit/84557cd61182edf7c776bd7d3284df5cacb22f7e), part of 6.6.49 stable kernel release. So we need to update our check to take that into account too, otherwise machines running an up-to-date LTS kernel will be unable to successfully build strace.

This theoretically makes us lose coverage for the 6.7 - 6.10 kernel range, but in reality 99% of riscv64 machines are running either the latest upstream kernel or a vendor kernel based on 6.6, so nothing really changes in practice.