### PR TITLE
colored output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ Noteworthy changes in release ?.?? (????-??-??)
 ===============================================
 
 * Improvements
+  * Implemented optional colorized trace output.
   * Implemented decoding of UDMABUF_CREATE and UDMABUF_CREATE_LIST ioctl
     commands.
 

--- a/configure.ac
+++ b/configure.ac
@@ -713,6 +713,21 @@ case "$ac_cv_search_mq_open" in
 esac
 AC_SUBST(mq_LIBS)
 
+termcap_LIBS=""
+AC_CHECK_HEADERS([termcap.h], [
+	saved_LIBS="$LIBS"
+	AC_SEARCH_LIBS([tgetnum], [tinfo ncurses termcap])
+	LIBS="$saved_LIBS"
+	if test "$ac_cv_search_tgetnum" != no; then
+		AC_DEFINE([HAVE_TGETNUM], [1],
+			  [Define to 1 if the system provides tgetnum])
+		case "$ac_cv_search_tgetnum" in
+			-l*) termcap_LIBS="$ac_cv_search_tgetnum" ;;
+		esac
+	fi
+])
+AC_SUBST(termcap_LIBS)
+
 AC_CHECK_TOOL([READELF], [readelf])
 
 st_STACKTRACE

--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -1111,6 +1111,53 @@ Opens the file provided in the
 .B \-o
 option in append mode.
 .TP
+.BR \-\-color = \fIwhen\fR
+Colorize the trace output.
+The default is
+.BR \-\-color = auto ,
+which enables color only when the trace output stream is a terminal
+(by default stderr; see
+.BR \-o )
+that supports at least 8 colors.  If the
+.B NO_COLOR
+environment variable is set, color is disabled unless
+.BR \-\-color = always
+is specified.
+The
+.I when
+parameter can be one of
+.BR auto ,
+.BR always ,
+or
+.BR never .
+Custom color schemes can be specified with the
+.B STRACE_COLORS
+environment variable, for example:
+.br
+.RS
+STRACE_COLORS="syscall=1;33:argname=39:argval=35:const=1;36:comment=36:punct=0:retval=32:error=31"
+.RE
+.IP
+The format of this value is
+.BR key = \fIvalue\fR
+pairs separated by
+.B :
+with semicolon-separated SGR codes as values.
+.IP
+The default palette uses standard ANSI colors (SGR 30\(en37) and bold
+attributes rather than bright colors (SGR 90\(en97), so that terminal
+color themes can adapt them for both dark and light backgrounds.
+.IP
+Recognized color keys are:
+.BR syscall ,
+.BR argname ,
+.BR argval ,
+.BR const ,
+.BR comment ,
+.BR punct ,
+.BR retval ,
+.BR error .
+.TP
 .B \-q
 .TQ
 .B \-\-quiet

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,7 +43,7 @@ include xlat/Makemodule.am
 strace_CPPFLAGS = $(AM_CPPFLAGS) -DIN_STRACE=1
 strace_CFLAGS = $(AM_CFLAGS)
 strace_LDFLAGS =
-strace_LDADD = libstrace.a $(clock_LIBS) $(timer_LIBS)
+strace_LDADD = libstrace.a $(clock_LIBS) $(timer_LIBS) $(termcap_LIBS)
 strace_SOURCES = strace.c
 
 noinst_PROGRAMS = \
@@ -87,6 +87,8 @@ libstrace_a_SOURCES =	\
 	chmod.c		\
 	clone.c		\
 	close_range.c	\
+	color.c		\
+	color.h		\
 	copy_file_range.c \
 	count.c		\
 	counter_ioctl.c	\

--- a/src/color.c
+++ b/src/color.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026 Jonas Jelten <jj@sft.lol>
+ * Copyright (c) 2026 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "defs.h"
+#include "color.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#ifdef HAVE_TGETNUM
+# include <termcap.h>
+#endif
+
+bool color_is_enabled = false;
+enum color_mode_t color_mode = COLOR_AUTO;
+const char *color_seq_table[COLOR_KIND_MAX];
+
+struct color_key {
+	const char *name;
+	enum color_kind_t kind;
+};
+
+#define DEF_COLOR_KEY(name)	{ #name, COLOR_ ## name }
+static const struct color_key color_keys[] = {
+	DEF_COLOR_KEY(ARGNAME),
+	DEF_COLOR_KEY(ARGVAL),
+	DEF_COLOR_KEY(COMMENT),
+	DEF_COLOR_KEY(CONST),
+	DEF_COLOR_KEY(ERROR),
+	DEF_COLOR_KEY(PUNCT),
+	DEF_COLOR_KEY(RETVAL),
+	DEF_COLOR_KEY(SYSCALL),
+};
+#undef DEF_COLOR_KEY
+
+/* Map a key name to a color kind, or COLOR_KIND_MAX if unknown. */
+static enum color_kind_t
+lookup_color_kind(const char *name)
+{
+	if (!name || !*name)
+		return COLOR_KIND_MAX;
+
+	for (size_t i = 0; i < ARRAY_SIZE(color_keys); i++) {
+		if (!strcasecmp(name, color_keys[i].name))
+			return color_keys[i].kind;
+	}
+
+	return COLOR_KIND_MAX;
+}
+
+/* Trim leading and trailing whitespace in-place and return the start. */
+static char *
+trim_spaces(char *s)
+{
+	if (!s)
+		return NULL;
+
+	while (isspace((unsigned char) *s))
+		++s;
+
+	char *end = s + strlen(s) - 1;
+	while (end > s && isspace((unsigned char) *end))
+		*end-- = '\0';
+
+	return s;
+}
+
+static const char *color_seq_table_default[COLOR_KIND_MAX] = {
+	"\033[39m",	/* ARGNAME:  foreground */
+	"\033[35m",	/* ARGVAL:   magenta */
+	"\033[36m",	/* COMMENT:  cyan */
+	"\033[34m",	/* CONST:    blue */
+	"\033[31m",	/* ERROR:    red */
+	"\033[0m",	/* PUNCT:    reset */
+	"\033[32m",	/* RETVAL:   green */
+	"\033[33m",	/* SYSCALL:  yellow */
+	"\033[0m",	/* RESET */
+};
+static const char **color_seq_table_def;
+
+/* Validate that the value is a raw SGR parameter list (only digits and ;) */
+static bool
+is_sgr_seq(const char *s)
+{
+	bool has_digit = false;
+
+	if (!s || !*s)
+		return false;
+
+	for (const unsigned char *p = (const unsigned char *) s; *p; ++p) {
+		if (isdigit(*p))
+			has_digit = true;
+		else if (*p != ';')
+			return false;
+	}
+
+	return has_digit;
+}
+
+/* Build an SGR escape sequence from a SGR parameter list. */
+static const char *
+make_sgr_seq(const char *str)
+{
+	return xasprintf("\033[%sm", str);
+}
+
+
+/*
+ * Parse STRACE_COLORS into color sequences, ignoring invalid parts.
+ * expected format: `colorname=sgrseq:...`,
+ * where sgrseq is a raw sgr parameter like `1;31`.
+ * so like LS_COLORS.
+ */
+static void
+parse_strace_colors(const char *spec)
+{
+	if (!spec || !*spec)
+		return;
+
+	char *buf = xstrdup(spec);
+	char *saveptr = NULL;
+
+	for (char *tok = strtok_r(buf, ":", &saveptr);
+	     tok; tok = strtok_r(NULL, ":", &saveptr)) {
+		char *eq = strchr(tok, '=');
+		if (!eq)
+			continue;
+		*eq++ = '\0';
+		char *key = trim_spaces(tok);
+		char *val = trim_spaces(eq);
+
+		enum color_kind_t kind = lookup_color_kind(key);
+		if (kind >= COLOR_KIND_MAX)
+			continue;
+		if (is_sgr_seq(val)) {
+			if (color_seq_table[kind] != color_seq_table_def[kind])
+				free((char *) color_seq_table[kind]);
+			color_seq_table[kind] = make_sgr_seq(val);
+		}
+	}
+
+	free(buf);
+}
+
+/*
+ * Return true when colors should be considered unavailable:
+ * either NO_COLOR is set or TERM indicates a non-color terminal.
+ */
+static bool
+is_no_color(void)
+{
+	if (getenv("NO_COLOR"))
+		return true;
+
+	const char *term = getenv("TERM");
+
+	if (!term || !*term)
+		return true;
+
+#ifdef HAVE_TGETNUM
+	return tgetent(NULL, term) <= 0 || tgetnum("Co") < 8;
+#else
+	return !strcasecmp(term, "dumb") ||
+	       !strcasecmp(term, "unknown");
+#endif
+}
+
+/*
+ * Initialize color output based on mode, trace output stream, and environment.
+ * Set NO_COLOR to disable in auto mode, or STRACE_COLORS to customize.
+ *
+ * output_separately says if we store per-pid output in separate files,
+ * where by default we won't store colors.  One can still set --color=always
+ * to include colors in the files (and view them with e.g. `less -R`).
+ */
+void
+color_init(int out_fd, bool output_separately)
+{
+	color_is_enabled = false;
+
+	if (color_mode == COLOR_NEVER)
+		return;
+
+	const bool is_tty = isatty(out_fd);
+	if (color_mode == COLOR_AUTO) {
+		if (!is_tty || output_separately || is_no_color())
+			return;
+	}
+
+	color_seq_table_def = color_seq_table_default;
+	memcpy(color_seq_table, color_seq_table_default, sizeof(color_seq_table));
+	parse_strace_colors(getenv("STRACE_COLORS"));
+
+	color_is_enabled = true;
+}

--- a/src/color.h
+++ b/src/color.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Jonas Jelten <jj@sft.lol>
+ * Copyright (c) 2026 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#ifndef STRACE_COLOR_H
+# define STRACE_COLOR_H
+
+# include <stdbool.h>
+
+enum color_mode_t {
+	COLOR_NEVER,
+	COLOR_AUTO,
+	COLOR_ALWAYS,
+};
+
+enum color_kind_t {
+	COLOR_ARGNAME,
+	COLOR_ARGVAL,
+	COLOR_COMMENT,
+	COLOR_CONST,
+	COLOR_ERROR,
+	COLOR_PUNCT,
+	COLOR_RETVAL,
+	COLOR_SYSCALL,
+
+	COLOR_RESET,
+	COLOR_KIND_MAX
+};
+
+extern enum color_mode_t color_mode;
+extern const char *color_seq_table[COLOR_KIND_MAX];
+extern bool color_is_enabled;
+
+void color_init(int out_fd, bool output_separately);
+
+static inline void
+tprint_color_seq(enum color_kind_t kind)
+{
+	if (color_is_enabled)
+		tprints_string_uncol(color_seq_table[kind]);
+}
+
+#endif /* STRACE_COLOR_H */

--- a/src/defs.h
+++ b/src/defs.h
@@ -1770,6 +1770,7 @@ extern void line_ended(void);
 extern void tabto(void);
 extern void tprintf_string(const char *fmt, ...) ATTRIBUTE_FORMAT((printf, 1, 2));
 extern void tprints_string(const char *str);
+extern bool tprints_string_uncol(const char *str);
 extern void tprintf_comment(const char *fmt, ...) ATTRIBUTE_FORMAT((printf, 1, 2));
 extern void tprints_comment(const char *str);
 

--- a/src/print_fields.h
+++ b/src/print_fields.h
@@ -10,10 +10,14 @@
 # define STRACE_PRINT_FIELDS_H
 
 # include "static_assert.h"
+# include <string.h>
 
 # ifdef IN_STRACE
 
+#  include "color.h"
+
 #  define STRACE_PRINTS(s_) tprints_string(s_)
+#  define STRACE_PRINT_COLOR_SEQ(kind_) tprint_color_seq(kind_)
 
 /*
  * The printf-like function to use in header files
@@ -33,73 +37,110 @@
  */
 #  define STRACE_PRINTF printf
 
+#  define COLOR_ARGNAME 0
+#  define COLOR_ARGVAL 0
+#  define COLOR_COMMENT 0
+#  define COLOR_CONST 0
+#  define COLOR_ERROR 0
+#  define COLOR_PUNCT 0
+#  define COLOR_RETVAL 0
+#  define COLOR_SYSCALL 0
+
+#  define COLOR_RESET 0
+
+#  define STRACE_PRINT_COLOR_SEQ(kind_) do { } while (0)
+
+#  define color_is_enabled 0
+
 # endif /* !IN_STRACE */
 
 
 static inline void
 tprint_struct_begin(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("{");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_struct_next(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS(", ");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_struct_end(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("}");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_union_begin(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("{");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_union_next(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS(", ");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_union_end(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("}");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_array_begin(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("[");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_array_next(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS(", ");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_array_end(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("]");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_array_index_begin(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("[");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_array_index_equal(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("]=");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
@@ -110,25 +151,37 @@ tprint_array_index_end(void)
 static inline void
 tprints_arg_begin(const char *name)
 {
-	STRACE_PRINTF("%s(", name);
+	STRACE_PRINT_COLOR_SEQ(COLOR_SYSCALL);
+	STRACE_PRINTF("%s", name);
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
+	STRACE_PRINTS("(");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_arg_next(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS(", ");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_arg_end(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS(")");
+	STRACE_PRINT_COLOR_SEQ(COLOR_RESET);
 }
 
 static inline void
 tprints_arg_name_unconditionally(const char *name)
 {
-	STRACE_PRINTF("%s=", name);
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGNAME);
+	STRACE_PRINTF("%s", name);
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
+	STRACE_PRINTS("=");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
@@ -157,91 +210,120 @@ tprints_arg_next_name(const char *name)
 static inline void
 tprint_bitset_begin(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("[");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_bitset_next(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS(" ");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_bitset_end(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("]");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_comment_begin(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_COMMENT);
 	STRACE_PRINTS(" /* ");
 }
 
 static inline void
 tprint_comment_end(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_COMMENT);
 	STRACE_PRINTS(" */");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_indirect_begin(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("[");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_indirect_end(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("]");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_attribute_begin(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("[");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_attribute_end(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("]");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_associated_info_begin(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("<");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_associated_info_end(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS(">");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_more_data_follows(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("...");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_value_changed(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS(" => ");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_alternative_value(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS(" or ");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_unavailable(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_ERROR);
 	STRACE_PRINTS("???");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
@@ -268,7 +350,9 @@ tprint_flags_begin(void)
 static inline void
 tprint_flags_or(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("|");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
@@ -297,25 +381,42 @@ tprint_null(void)
 static inline void
 tprint_newline(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_RESET);
 	STRACE_PRINTS("\n");
 }
 
 static inline void
 tprints_field_name(const char *name)
 {
-	STRACE_PRINTF("%s=", name);
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGNAME);
+	STRACE_PRINTF("%s", name);
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
+	STRACE_PRINTS("=");
+	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
 }
 
 static inline void
 tprint_sysret_begin(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("=");
+	STRACE_PRINT_COLOR_SEQ(COLOR_RESET);
 }
 
 static inline void
 tprints_sysret_next(const char *name)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_RESET);
 	tprint_space();
+	if (color_is_enabled && name) {
+		if (!strcmp(name, "error") ||
+		    !strcmp(name, "errno") ||
+		    !strcmp(name, "strerror")) {
+			STRACE_PRINT_COLOR_SEQ(COLOR_ERROR);
+			return;
+		}
+	}
+	STRACE_PRINT_COLOR_SEQ(COLOR_RETVAL);
 }
 
 static inline void
@@ -334,6 +435,7 @@ tprint_sysret_pseudo_rval(void)
 static inline void
 tprint_sysret_end(void)
 {
+	STRACE_PRINT_COLOR_SEQ(COLOR_RESET);
 }
 
 # define PRINT_VAL_D(val_)	\

--- a/src/strace.c
+++ b/src/strace.c
@@ -3590,7 +3590,8 @@ print_event_exit(struct tcb *tcp)
 		tprints_string("<unfinished ...>");
 	}
 
-	tprints_string(") ");
+	tprint_arg_end();
+	tprint_space();
 	tabto();
 	tprint_sysret_begin();
 	tprints_sysret_next("retval");

--- a/src/strace.c
+++ b/src/strace.c
@@ -29,6 +29,7 @@
 #include <sys/prctl.h>
 
 #include "kill_save_errno.h"
+#include "color.h"
 #include "exitkill.h"
 #include "filter_seccomp.h"
 #include "largefile_wrappers.h"
@@ -77,6 +78,11 @@ static const struct xlat_data xflag_str[] = {
 	{ HEXSTR_NON_ASCII_CHARS,	"non-ascii-chars" },
 	{ HEXSTR_NON_ASCII,		"non-ascii" },
 	{ HEXSTR_ALL,			"all" },
+};
+static const struct xlat_data color_mode_str[] = {
+	{ COLOR_AUTO,	"auto" },
+	{ COLOR_NEVER,	"never" },
+	{ COLOR_ALWAYS,	"always" },
 };
 unsigned int xflag;
 bool debug_flag;
@@ -363,6 +369,8 @@ Filtering:\n\
 Output format:\n\
   -a COLUMN, --columns=COLUMN\n\
                  alignment COLUMN for printing syscall results (default %d)\n\
+  --color[=WHEN]\n\
+                 colorize output; WHEN is auto, always, or never (default auto)\n\
   -e abbrev=SET, --abbrev=SET\n\
                  abbreviate output for the syscalls in SET\n\
   -e verbose=SET, --verbose=SET\n\
@@ -771,18 +779,24 @@ tprintf_string(const char *fmt, ...)
 # define fputs_unlocked fputs
 #endif
 
-void
-tprints_string(const char *str)
+bool
+tprints_string_uncol(const char *str)
 {
 	if (current_tcp) {
 		int n = fputs_unlocked(str, current_tcp->outf);
-		if (n >= 0) {
-			current_tcp->curcol += strlen(str);
-			return;
-		}
+		if (n >= 0)
+			return true;
 		/* very unlikely due to fputs_unlocked buffering */
 		outf_perror(current_tcp);
 	}
+	return false;
+}
+
+void
+tprints_string(const char *str)
+{
+	if (tprints_string_uncol(str))
+		current_tcp->curcol += strlen(str);
 }
 
 void
@@ -2349,7 +2363,7 @@ init(int argc, char *argv[])
 		GETOPT_ARGV0,
 		GETOPT_STACK_TRACE_FRAME_LIMIT,
 		GETOPT_ALWAYS_SHOW_PID,
-
+		GETOPT_COLOR,
 		GETOPT_QUAL_TRACE,
 		GETOPT_QUAL_TRACE_FD,
 		GETOPT_QUAL_ABBREV,
@@ -2417,7 +2431,7 @@ init(int argc, char *argv[])
 		{ "tips",		optional_argument, 0, GETOPT_TIPS },
 		{ "argv0",		required_argument, 0, GETOPT_ARGV0 },
 		{ "always-show-pid",	no_argument,	   0, GETOPT_ALWAYS_SHOW_PID },
-
+		{ "color",		required_argument, 0, GETOPT_COLOR },
 		{ "trace",	required_argument, 0, GETOPT_QUAL_TRACE },
 		{ "trace-fds",	required_argument, 0, GETOPT_QUAL_TRACE_FD },
 		{ "abbrev",	required_argument, 0, GETOPT_QUAL_ABBREV },
@@ -2437,7 +2451,6 @@ init(int argc, char *argv[])
 		{ "decode-fds",	optional_argument, 0, GETOPT_QUAL_DECODE_FD },
 		{ "decode-pids",required_argument, 0, GETOPT_QUAL_DECODE_PID },
 		{ "secontext",	optional_argument, 0, GETOPT_QUAL_SECONTEXT },
-
 		{ 0, 0, 0, 0 }
 	};
 
@@ -2719,6 +2732,15 @@ init(int argc, char *argv[])
 		case GETOPT_ALWAYS_SHOW_PID:
 			always_show_pid = true;
 			break;
+		case GETOPT_COLOR: {
+			int color_mode_raw =
+				(int) find_arg_val(optarg, color_mode_str,
+						   -1, -1);
+			if (color_mode_raw < 0)
+				error_opt_arg(c, lopt, optarg);
+			color_mode = (enum color_mode_t) color_mode_raw;
+			break;
+		}
 		case GETOPT_QUAL_SECONTEXT:
 			qualify_secontext(optarg ? optarg : secontext_qual);
 			break;
@@ -3096,6 +3118,8 @@ init(int argc, char *argv[])
 	if (!outfname || outfname[0] == '|' || outfname[0] == '!') {
 		setvbuf(shared_log, NULL, _IOLBF, 0);
 	}
+
+	color_init(fileno(shared_log), output_separately);
 
 	/*
 	 * argv[0]	-pPID	-oFILE	Default interactive setting

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -672,6 +672,7 @@ syscall_entering_trace(struct tcb *tcp, unsigned int *sig)
 	printleader(tcp);
 	tprints_arg_begin(tcp_sysent(tcp)->sys_name);
 	int res = raw(tcp) ? printargs(tcp) : tcp_sysent(tcp)->sys_func(tcp);
+	STRACE_PRINT_COLOR_SEQ(COLOR_RESET);
 	fflush(tcp->outf);
 	return res;
 }

--- a/src/xlat.c
+++ b/src/xlat.c
@@ -10,6 +10,7 @@
  */
 
 #include "defs.h"
+#include "color.h"
 #include "xstring.h"
 #include <stdarg.h>
 
@@ -48,6 +49,17 @@ static void
 print_xlat_val(uint64_t val, enum xlat_style style)
 {
 	tprints_string(sprint_xlat_val(val, style));
+}
+
+static void
+tprints_xlat_const(const char *str)
+{
+	if (!str || !*str)
+		return;
+
+	tprint_color_seq(COLOR_CONST);
+	tprints_string(str);
+	tprint_color_seq(COLOR_ARGVAL);
 }
 
 static int
@@ -244,7 +256,7 @@ printxvals_ex(const uint64_t val, const char *dflt, enum xlat_style style,
 				print_xlat_val(val, style);
 				tprints_comment(str);
 			} else {
-				tprints_string(str);
+				tprints_xlat_const(str);
 			}
 
 			goto printxvals_ex_end;
@@ -450,7 +462,10 @@ printflags_ex(uint64_t flags, const char *dflt, enum xlat_style style,
 					tprint_flags_or();
 				else if (need_comment)
 					tprint_comment_begin();
-				tprints_string(xlat->data[idx].str);
+				if (need_comment)
+					tprints_string(xlat->data[idx].str);
+				else
+					tprints_xlat_const(xlat->data[idx].str);
 				flags &= ~v;
 			}
 			if (!flags)
@@ -495,7 +510,7 @@ print_xlat_ex(const uint64_t val, const char *str, uint32_t style)
 				print_xlat_val(val, style);
 				tprints_comment(str);
 			} else {
-				tprints_string(str);
+				tprints_xlat_const(str);
 			}
 			break;
 		}

--- a/src/xlat.c
+++ b/src/xlat.c
@@ -431,15 +431,12 @@ printflags_ex(uint64_t flags, const char *dflt, enum xlat_style style,
 		return 0;
 	}
 
-	bool need_comment = false;
+	const bool need_comment = xlat_verbose(style) == XLAT_STYLE_VERBOSE;
 	unsigned int n = 0;
 	va_list args;
 
-	if (xlat_verbose(style) == XLAT_STYLE_VERBOSE) {
-		need_comment = true;
-		if (flags)
-			print_xlat_val(flags, style);
-	}
+	if (need_comment && flags)
+		print_xlat_val(flags, style);
 
 	va_start(args, xlat);
 	for (; xlat; xlat = va_arg(args, const struct xlat *)) {
@@ -447,8 +444,7 @@ printflags_ex(uint64_t flags, const char *dflt, enum xlat_style style,
 			uint64_t v = xlat->data[idx].val;
 			if (xlat->data[idx].str
 			    && ((flags == v) || (v && (flags & v) == v))) {
-				if (xlat_verbose(style) == XLAT_STYLE_VERBOSE
-				    && !flags)
+				if (need_comment && !flags)
 					PRINT_VAL_U(0);
 				if (n++)
 					tprint_flags_or();
@@ -470,7 +466,7 @@ printflags_ex(uint64_t flags, const char *dflt, enum xlat_style style,
 			n++;
 		}
 
-		if (xlat_verbose(style) == XLAT_STYLE_VERBOSE)
+		if (need_comment)
 			tprint_comment_end();
 	} else {
 		if (flags) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -696,6 +696,8 @@ MISC_TESTS = \
 	status-none-threads.test \
 	status-successful-threads.test \
 	status-unfinished-threads.test \
+	strace--color-no-tty.test \
+	strace--color-tty.test \
 	strace--argv0.test \
 	strace--syscall-limit.test \
 	strace--syscall-limit--seccomp-bpf.test \

--- a/tests/options-syntax.test
+++ b/tests/options-syntax.test
@@ -101,6 +101,8 @@ do
 done
 
 check_h 'PROG [ARGS] must be specified with --argv0' --argv0=sample -p $$
+check_h "invalid --color argument: 'foo'" --color=foo
+check_h "invalid --color argument: 'auto,never'" --color=auto,never
 check_h 'PROG [ARGS] must be specified with -D/--daemonize' -D -p $$
 check_h 'PROG [ARGS] must be specified with -D/--daemonize' -DD -p $$
 check_h 'PROG [ARGS] must be specified with -D/--daemonize' -DDD -p $$

--- a/tests/strace--color-no-tty.test
+++ b/tests/strace--color-no-tty.test
@@ -1,0 +1,101 @@
+#!/bin/sh -efu
+#
+# Check --color, STRACE_COLORS, and NO_COLOR handling.
+#
+# Copyright (c) 2026 Jonas Jelten <jj@sft.lol>
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+run_prog ../getpid > /dev/null
+run_prog ../chdir > /dev/null
+
+csi="$(printf '\033\\[')"
+
+unset STRACE_COLORS
+unset NO_COLOR
+
+TERM=linux
+export TERM
+
+LOG=log.color-default
+EXP=exp.color-default
+run_strace --trace=getpid --color=always ../getpid > /dev/null
+printf '%s\n' ".*${csi}33mgetpid.*${csi}0m.*" > "$EXP"
+match_grep "$LOG" "$EXP"
+
+LOG=log.color-empty-spec
+EXP=exp.color-empty-spec
+STRACE_COLORS=''
+export STRACE_COLORS
+run_strace --trace=getpid --color=always ../getpid > /dev/null
+printf '%s\n' ".*${csi}33mgetpid.*${csi}0m.*" > "$EXP"
+match_grep "$LOG" "$EXP"
+
+LOG=log.color-empty-value
+EXP=exp.color-empty-value
+STRACE_COLORS='syscall='
+export STRACE_COLORS
+run_strace --trace=getpid --color=always ../getpid > /dev/null
+printf '%s\n' ".*${csi}33mgetpid.*${csi}0m.*" > "$EXP"
+match_grep "$LOG" "$EXP"
+
+LOG=log.color-custom
+EXP=exp.color-custom
+STRACE_COLORS=' SyScAlL = 1;31 : unknown = 1;36 '
+export STRACE_COLORS
+run_strace --trace=getpid --color=always ../getpid > /dev/null
+printf '%s\n' ".*${csi}1;31mgetpid.*${csi}0m.*" > "$EXP"
+match_grep "$LOG" "$EXP"
+
+LOG=log.color-invalid
+EXP=exp.color-invalid
+STRACE_COLORS='syscall=1;31;foo'
+export STRACE_COLORS
+run_strace --trace=getpid --color=always ../getpid > /dev/null
+printf '%s\n' \
+	".*${csi}33mgetpid.*${csi}0m.*" \
+	"!.*${csi}1;31mgetpid.*" \
+	> "$EXP"
+match_grep "$LOG" "$EXP"
+
+LOG=log.color-multi
+EXP=exp.color-multi
+STRACE_COLORS='syscall=93:syscall=1;31:argval=1;32:punct=1;34'
+export STRACE_COLORS
+run_strace --trace=chdir --color=always ../chdir > /dev/null
+printf '%s\n' \
+	".*${csi}1;31mchdir.*" \
+	".*${csi}1;34m\\(.*" \
+	".*${csi}1;32m\".*" \
+	> "$EXP"
+match_grep "$LOG" "$EXP"
+
+LOG=log.color-never
+EXP=exp.color-never
+# STRACE_COLORS remains set
+run_strace --trace=getpid --color=never ../getpid > /dev/null
+printf '%s\n' "!.*${csi}.*" > "$EXP"
+match_grep "$LOG" "$EXP"
+
+LOG=log.color-auto-nocolor
+EXP=exp.color-auto-nocolor
+NO_COLOR=1
+export NO_COLOR
+STRACE_COLORS='syscall=1;31'
+export STRACE_COLORS
+run_strace --trace=getpid --color=auto ../getpid > /dev/null
+printf '%s\n' "!.*${csi}.*" > "$EXP"
+match_grep "$LOG" "$EXP"
+unset STRACE_COLORS
+
+LOG=log.color-always
+EXP=exp.color-always
+# NO_COLOR remains set
+run_strace --trace=getpid --color=always ../getpid > /dev/null
+printf '%s\n' ".*${csi}33mgetpid.*${csi}0m.*" > "$EXP"
+match_grep "$LOG" "$EXP"
+unset NO_COLOR

--- a/tests/strace--color-tty.test
+++ b/tests/strace--color-tty.test
@@ -1,0 +1,34 @@
+#!/bin/sh -efu
+#
+# Check --color=auto with a tty.
+#
+# Copyright (c) 2026 Dmitry V. Levin <ldv@strace.io>
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+unset STRACE_COLORS
+unset NO_COLOR
+
+TERM=linux
+export TERM
+
+check_prog script
+run_prog ../getpid > /dev/null
+
+csi="$(printf '\033\\[')"
+printf '%s\n' ".*${csi}33mgetpid.*${csi}0m.*" > "$EXP"
+cmd="$STRACE --trace=getpid ../getpid > /dev/null"
+set -- script -q -e -c "$cmd" /dev/null
+"$@" > "$LOG" ||
+	dump_log_and_fail_with "$* failed with code $?"
+match_grep "$LOG" "$EXP"
+
+TERM=dumb
+printf '%s\n' "!.*${csi}.*" > "$EXP"
+"$@" > "$LOG" ||
+	dump_log_and_fail_with "$* failed with code $?"
+match_grep "$LOG" "$EXP"


### PR DESCRIPTION
I was amazed when `gdb` finally supported colors. but my favorite debugging tool `strace` was still plain output only.

so i did something i've wanted for years:
this is **colors for strace**!

- in case you're using strace in an highest-performance environment, compile-time disable colors with `./configure --enable-colors=no`
- there's a single branch checking if coloring is enabled in `color_seq`
- i've set the default to `strace --color=auto`, which only enables colors if the output file (usually stderr) is a tty
- i've used colors similar to the vim color scheme in `ft=strace`, so vim users don't have to adjust their eyes much
- you can customize the color scheme using `STRACE_COLORS="syscall=91:constant=92" strace ls` (like `LS_COLORS`)
- it detects your terminal background color luminance to select the bright/dark color theme defaults

i'm very happy if you have any feedback!

we'd like to include coloring in Ubuntu 26.04, so it would be great if you could quickly raise any concerns about coloring/this approach in general (since its feature freeze is very very soon).

example output with `strace ls` in its source dir:
<img width="1272" height="1090" alt="image" src="https://github.com/user-attachments/assets/a7822e91-73c4-45c5-9221-ae88a7c4d20c" />


closes #39 