### PR TITLE
udmabuf: decode ioctls

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@ Noteworthy changes in release ?.?? (????-??-??)
 ===============================================
 
 * Improvements
+  * Implemented decoding of UDMABUF_CREATE and UDMABUF_CREATE_LIST ioctl
+    commands.
 
 Noteworthy changes in release 6.19 (2026-02-10)
 ===============================================

--- a/bundled/Makefile.am
+++ b/bundled/Makefile.am
@@ -137,6 +137,7 @@ EXTRA_DIST = \
 	linux/include/uapi/linux/tls.h \
 	linux/include/uapi/linux/typelimits.h \
 	linux/include/uapi/linux/types.h \
+	linux/include/uapi/linux/udmabuf.h \
 	linux/include/uapi/linux/unix_diag.h \
 	linux/include/uapi/linux/userfaultfd.h \
 	linux/include/uapi/linux/utsname.h \

--- a/bundled/linux/include/uapi/linux/udmabuf.h
+++ b/bundled/linux/include/uapi/linux/udmabuf.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+#ifndef _LINUX_UDMABUF_H
+#define _LINUX_UDMABUF_H
+
+#include <linux/types.h>
+#include <linux/ioctl.h>
+
+#define UDMABUF_FLAGS_CLOEXEC	0x01
+
+struct udmabuf_create {
+	__u32 memfd;
+	__u32 flags;
+	__u64 offset;
+	__u64 size;
+};
+
+struct udmabuf_create_item {
+	__u32 memfd;
+	__u32 __pad;
+	__u64 offset;
+	__u64 size;
+};
+
+struct udmabuf_create_list {
+	__u32 flags;
+	__u32 count;
+	struct udmabuf_create_item list[];
+};
+
+#define UDMABUF_CREATE       _IOW('u', 0x42, struct udmabuf_create)
+#define UDMABUF_CREATE_LIST  _IOW('u', 0x43, struct udmabuf_create_list)
+
+#endif /* _LINUX_UDMABUF_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -403,6 +403,7 @@ libstrace_a_SOURCES =	\
 	truncate.c	\
 	ubi.c		\
 	ucopy.c		\
+	udmabuf.c	\
 	uid.c		\
 	uid16.c		\
 	umask.c		\

--- a/src/defs.h
+++ b/src/defs.h
@@ -1482,6 +1482,7 @@ DECL_IOCTL(scsi);
 DECL_IOCTL(tee);
 DECL_IOCTL(term);
 DECL_IOCTL(ubi);
+DECL_IOCTL(udmabuf);
 DECL_IOCTL(uffdio);
 DECL_IOCTL(watchdog);
 # undef DECL_IOCTL

--- a/src/ioctl.c
+++ b/src/ioctl.c
@@ -465,6 +465,8 @@ ioctl_decode(struct tcb *tcp, const struct finfo *finfo)
 	case 't':
 		return term_ioctl(tcp, code, arg);
 #endif
+	case 'u':
+		return udmabuf_ioctl(tcp, code, arg);
 	case 0x89:
 		return sock_ioctl(tcp, code, arg);
 	case 0x8a:

--- a/src/udmabuf.c
+++ b/src/udmabuf.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "defs.h"
+#include <linux/udmabuf.h>
+#include "xlat/udmabuf_flags.h"
+
+static int
+print_udmabuf_create(struct tcb *tcp, kernel_ulong_t arg)
+{
+	struct udmabuf_create uc;
+
+	tprints_arg_next_name("argp");
+	if (umove_or_printaddr(tcp, arg, &uc))
+		return RVAL_IOCTL_DECODED;
+
+	tprint_struct_begin();
+	PRINT_FIELD_FD(uc, memfd, tcp);
+	tprint_struct_next();
+	PRINT_FIELD_FLAGS(uc, flags, udmabuf_flags, "UDMABUF_FLAGS_???");
+	tprint_struct_next();
+	PRINT_FIELD_U(uc, offset);
+	tprint_struct_next();
+	PRINT_FIELD_U(uc, size);
+	tprint_struct_end();
+
+	return RVAL_IOCTL_DECODED | RVAL_FD;
+}
+
+static bool
+print_udmabuf_create_item(struct tcb *tcp, void *data, size_t size, void *closure)
+{
+	struct udmabuf_create_item *item = data;
+
+	tprint_struct_begin();
+	PRINT_FIELD_FD(*item, memfd, tcp);
+	tprint_struct_next();
+	PRINT_FIELD_U(*item, offset);
+	tprint_struct_next();
+	PRINT_FIELD_U(*item, size);
+	tprint_struct_end();
+
+	return true;
+}
+
+static int
+print_udmabuf_create_list(struct tcb *tcp, kernel_ulong_t arg)
+{
+	struct udmabuf_create_list uc;
+
+	tprints_arg_next_name("argp");
+	if (umove_or_printaddr(tcp, arg, &uc))
+		return RVAL_IOCTL_DECODED;
+
+	tprint_struct_begin();
+	PRINT_FIELD_FLAGS(uc, flags, udmabuf_flags, "UDMABUF_FLAGS_???");
+	tprint_struct_next();
+	PRINT_FIELD_U(uc, count);
+
+	static const size_t list_offset = offsetof(struct udmabuf_create_list, list);
+	struct udmabuf_create_item item;
+
+	tprint_struct_next();
+	tprints_field_name("list");
+	print_array(tcp, arg + list_offset, uc.count, &item, sizeof(item),
+		    tfetch_mem, print_udmabuf_create_item, NULL);
+
+	tprint_struct_end();
+
+	return RVAL_IOCTL_DECODED | RVAL_FD;
+}
+
+int
+udmabuf_ioctl(struct tcb *const tcp, const unsigned int code, const kernel_ulong_t arg)
+{
+	switch (code) {
+	case UDMABUF_CREATE:
+		return print_udmabuf_create(tcp, arg);
+	case UDMABUF_CREATE_LIST:
+		return print_udmabuf_create_list(tcp, arg);
+	default:
+		return RVAL_DECODED;
+	}
+}

--- a/src/xlat/udmabuf_flags.in
+++ b/src/xlat/udmabuf_flags.in
@@ -1,0 +1,4 @@
+#unconditional
+#From include/uapi/linux/udmabuf.h
+#Prefix UDMABUF_FLAGS_
+UDMABUF_FLAGS_CLOEXEC

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -453,6 +453,7 @@ ioctl_termios-v
 ioctl_tiocm
 ioctl_ubi
 ioctl_ubi-success
+ioctl_udmabuf
 ioctl_uffdio
 ioctl_v4l2
 ioctl_v4l2-Xabbrev

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -474,6 +474,7 @@ ioctl_termios-v	+ioctl.test -v
 ioctl_tiocm	+ioctl.test
 ioctl_ubi	+ioctl.test
 ioctl_ubi-success	+ioctl-success.sh -a24
+ioctl_udmabuf	+ioctl.test -y
 ioctl_uffdio	+ioctl.test
 ioctl_v4l2	+ioctl.test
 ioctl_v4l2-Xabbrev	+ioctl.test -Xabbrev

--- a/tests/ioctl_udmabuf.c
+++ b/tests/ioctl_udmabuf.c
@@ -1,0 +1,124 @@
+/*
+ * Check decoding of UDMABUF_* ioctl commands.
+ *
+ * Copyright (c) 2026 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "tests.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/ioctl.h>
+#include <linux/udmabuf.h>
+
+static const struct {
+	struct strval32 memfd;
+	struct strval32 flags;
+	struct strval64 offset;
+	struct strval64 size;
+} create_tests[] = {
+	{
+		{ ARG_STR(-1) },
+		{ ARG_STR(0) },
+		{ -2, "18446744073709551614" },
+		{ -3, "18446744073709551613" },
+	}, {
+		{ 0, "0</dev/null>" },
+		{ ARG_STR(UDMABUF_FLAGS_CLOEXEC) },
+		{ -2U, "4294967294" },
+		{ -3U, "4294967293" },
+	}, {
+		{ ARG_STR(-1) },
+		{ -1, "UDMABUF_FLAGS_CLOEXEC|0xfffffffe" },
+		{ ARG_STR(123456789) },
+		{ ARG_STR(234567890) },
+	}, {
+		{ 0, "0</dev/null>" },
+		{ ARG_STR(0xfffffffe) " /* UDMABUF_FLAGS_??? */" },
+		{ ARG_STR(345678901) },
+		{ ARG_STR(456789012) },
+	},
+};
+
+static void
+test_create(void)
+{
+	TAIL_ALLOC_OBJECT_CONST_PTR(struct udmabuf_create, p_udmabuf_create);
+
+	ioctl(-1, UDMABUF_CREATE, NULL);
+	printf("ioctl(-1, UDMABUF_CREATE, NULL)" RVAL_EBADF);
+
+	for (size_t i = 0; i < ARRAY_SIZE(create_tests); i++) {
+		p_udmabuf_create->memfd = create_tests[i].memfd.val;
+		p_udmabuf_create->flags = create_tests[i].flags.val;
+		p_udmabuf_create->offset = create_tests[i].offset.val;
+		p_udmabuf_create->size = create_tests[i].size.val;
+
+		ioctl(-1, UDMABUF_CREATE, p_udmabuf_create);
+		printf("ioctl(-1, UDMABUF_CREATE"
+		       ", {memfd=%s, flags=%s, offset=%s, size=%s})" RVAL_EBADF,
+		       create_tests[i].memfd.str,
+		       create_tests[i].flags.str,
+		       create_tests[i].offset.str,
+		       create_tests[i].size.str);
+	}
+}
+
+static void
+test_create_list(void)
+{
+	ioctl(-1, UDMABUF_CREATE_LIST, NULL);
+	printf("ioctl(-1, UDMABUF_CREATE_LIST, NULL)" RVAL_EBADF);
+
+	struct udmabuf_create_list *const p_udmabuf_create_list = tail_alloc(
+		offsetof(struct udmabuf_create_list, list)
+		+ sizeof(struct udmabuf_create_item) * ARRAY_SIZE(create_tests)
+	);
+
+	p_udmabuf_create_list->count = ARRAY_SIZE(create_tests);
+
+	for (size_t i = 0; i < ARRAY_SIZE(create_tests); i++) {
+		p_udmabuf_create_list->list[i].memfd = create_tests[i].memfd.val;
+		p_udmabuf_create_list->list[i].offset = create_tests[i].offset.val;
+		p_udmabuf_create_list->list[i].size = create_tests[i].size.val;
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(create_tests); i++) {
+		p_udmabuf_create_list->flags = create_tests[i].flags.val;
+
+		ioctl(-1, UDMABUF_CREATE_LIST, p_udmabuf_create_list);
+		printf("ioctl(-1, UDMABUF_CREATE_LIST"
+		       ", {flags=%s, count=%u, list=[",
+		       create_tests[i].flags.str,
+		       p_udmabuf_create_list->count);
+
+		for (size_t j = 0; j < ARRAY_SIZE(create_tests); j++) {
+			if (j > 0)
+				printf(", ");
+
+			printf("{memfd=%s, offset=%s, size=%s}",
+			       create_tests[j].memfd.str,
+			       create_tests[j].offset.str,
+			       create_tests[j].size.str);
+		}
+
+		printf("]})" RVAL_EBADF);
+	}
+}
+
+int
+main(void)
+{
+	skip_if_unavailable("/proc/self/fd/");
+
+	test_create();
+	test_create_list();
+
+	puts("+++ exited with 0 +++");
+	return 0;
+}

--- a/tests/pure_executables.list
+++ b/tests/pure_executables.list
@@ -304,6 +304,7 @@ ioctl_termios
 ioctl_termios-v
 ioctl_tiocm
 ioctl_ubi
+ioctl_udmabuf
 ioctl_uffdio
 ioctl_v4l2
 ioctl_v4l2-Xabbrev


### PR DESCRIPTION
Decode the two currently supported udmabuf ioctls: `UDMABUF_CREATE`, and `UDMABUF_CREATE_LIST`. Every field is supported.
