### PR TITLE
v4l2: decode `VIDIOC_QUERYMENU`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,8 +4,8 @@ Noteworthy changes in release ?.?? (????-??-??)
 * Improvements
   * Implemented optional colorized trace output.
   * Implemented decoding of rseq syscall.
-  * Implemented decoding of UDMABUF_CREATE and UDMABUF_CREATE_LIST ioctl
-    commands.
+  * Implemented decoding of UDMABUF_CREATE, UDMABUF_CREATE_LIST,
+    and VIDIOC_QUERYMENU ioctl commands.
   * Updated lists of ioctl commands from Linux 7.0.
 
 Noteworthy changes in release 6.19 (2026-02-10)

--- a/src/v4l2.c
+++ b/src/v4l2.c
@@ -1147,6 +1147,36 @@ print_v4l2_queryctrl(struct tcb *const tcp, const kernel_ulong_t arg)
 }
 
 static int
+print_v4l2_querymenu(struct tcb *const tcp, const kernel_ulong_t arg)
+{
+	struct v4l2_querymenu qm;
+
+	if (entering(tcp)) {
+		tprints_arg_next_name("argp");
+		if (umove_or_printaddr(tcp, arg, &qm))
+			return RVAL_IOCTL_DECODED;
+
+		tprint_struct_begin();
+		PRINT_FIELD_V4L2_CID(qm, id, false);
+		tprint_struct_next();
+		PRINT_FIELD_U(qm, index);
+
+		return 0;
+	}
+
+	if (!syserror(tcp) && !umove(tcp, arg, &qm)) {
+		tprint_struct_end_value_changed_struct_begin();
+		PRINT_FIELD_CSTRING(qm, name);
+		tprint_struct_next();
+		PRINT_FIELD_D(qm, value);
+	}
+
+	tprint_struct_end();
+
+	return RVAL_IOCTL_DECODED;
+}
+
+static int
 print_v4l2_query_ext_ctrl(struct tcb *const tcp, const kernel_ulong_t arg)
 {
 	struct v4l2_query_ext_ctrl c;
@@ -1652,6 +1682,9 @@ MPERS_PRINTER_DECL(int, v4l2_ioctl, struct tcb *const tcp,
 
 	case VIDIOC_CREATE_BUFS: /* RW */
 		return print_v4l2_create_buffers(tcp, arg);
+
+	case VIDIOC_QUERYMENU: /* RW */
+		return print_v4l2_querymenu(tcp, arg);
 
 	default:
 		return RVAL_DECODED;

--- a/tests/ioctl_v4l2-success.c
+++ b/tests/ioctl_v4l2-success.c
@@ -1735,6 +1735,35 @@ main(int argc, char **argv)
 		}
 	}
 
+	/* VIDIOC_QUERYMENU */
+	TAIL_ALLOC_OBJECT_CONST_PTR(struct v4l2_querymenu, qmenu);
+	fill_memory32(qmenu, sizeof(*qmenu));
+
+	ioctl(-1, VIDIOC_QUERYMENU, 0);
+	printf("ioctl(-1, %s, NULL) = %ld (INJECTED)\n",
+	       XLAT_STR(VIDIOC_QUERYMENU), inject_retval);
+
+	ioctl(-1, VIDIOC_QUERYMENU, (char *) qmenu + 1);
+	printf("ioctl(-1, %s, %p) = %ld (INJECTED)\n",
+	       XLAT_STR(VIDIOC_QUERYMENU),
+	       (char *) qmenu + 1, inject_retval);
+
+	static const char qmenu_name[] = "Aperture Priority Mode";
+	qmenu->id = V4L2_CID_EXPOSURE_AUTO;
+	strcpy((char *) qmenu->name, qmenu_name);
+
+	ioctl(-1, VIDIOC_QUERYMENU, qmenu);
+	printf("ioctl(-1, %s, {id=" NABBR("%#x") VERB(" /* ")
+	       NRAW("V4L2_CID_EXPOSURE_AUTO") VERB(" */") ", "
+	       "index=%u} => {name=\"%s\", value=%jd}) = %ld (INJECTED)\n",
+	       XLAT_STR(VIDIOC_QUERYMENU),
+	       NABBR(qmenu->id,)
+	       qmenu->index,
+	       qmenu_name,
+	       (intmax_t) qmenu->value,
+	       inject_retval
+	);
+
 	puts("+++ exited with 0 +++");
 
 	return 0;

--- a/tests/ioctl_v4l2-success.c
+++ b/tests/ioctl_v4l2-success.c
@@ -7,6 +7,7 @@
 
 #include "tests.h"
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1734,6 +1735,43 @@ main(int argc, char **argv)
 			memset(qextc->reserved, 0, sizeof(qextc->reserved));
 		}
 	}
+
+	/* VIDIOC_QUERYMENU */
+	TAIL_ALLOC_OBJECT_CONST_PTR(struct v4l2_querymenu, qmenu);
+	fill_memory32(qmenu, sizeof(*qmenu));
+
+	ioctl(-1, VIDIOC_QUERYMENU, 0);
+	printf("ioctl(-1, %s, NULL) = %ld (INJECTED)\n",
+	       XLAT_STR(VIDIOC_QUERYMENU), inject_retval);
+
+	ioctl(-1, VIDIOC_QUERYMENU, (char *) qmenu + 1);
+	printf("ioctl(-1, %s, %p) = %ld (INJECTED)\n",
+	       XLAT_STR(VIDIOC_QUERYMENU),
+	       (char *) qmenu + 1, inject_retval);
+
+	static const char qmenu_name[] = "Aperture Priority Mode";
+
+	int64_t qmenu_value;
+	memcpy(&qmenu_value, qmenu_name, sizeof(qmenu_value));
+
+	qmenu->id = V4L2_CID_EXPOSURE_AUTO;
+	strcpy((char *) qmenu->name, qmenu_name);
+
+	ioctl(-1, VIDIOC_QUERYMENU, qmenu);
+	printf("ioctl(-1, %s, {"
+	       "id=" NABBR("%#x") VERB(" /* ") NRAW("V4L2_CID_EXPOSURE_AUTO") VERB(" */") ", "
+	       "index=%u"
+	       "} => {"
+	       "name=\"%s\", "
+	       "value=%" PRId64
+	       "}) = %ld (INJECTED)\n",
+	       XLAT_STR(VIDIOC_QUERYMENU),
+	       NABBR(qmenu->id,)
+	       qmenu->index,
+	       qmenu_name,
+	       qmenu_value,
+	       inject_retval
+	);
 
 	puts("+++ exited with 0 +++");
 

--- a/tests/ioctl_v4l2.c
+++ b/tests/ioctl_v4l2.c
@@ -502,7 +502,6 @@ main(void)
 		{ ARG_STR(VIDIOC_OVERLAY) },
 		{ ARG_STR(VIDIOC_G_AUDIO) },
 		{ ARG_STR(VIDIOC_S_AUDIO) },
-		{ ARG_STR(VIDIOC_QUERYMENU) },
 		{ ARG_STR(VIDIOC_G_EDID) },
 		{ ARG_STR(VIDIOC_S_EDID) },
 		{ ARG_STR(VIDIOC_G_OUTPUT) },
@@ -1357,6 +1356,25 @@ main(void)
 	       p_v4l2_expbuf->index,
 	       p_v4l2_expbuf->plane
 	       NABBR(, p_v4l2_expbuf->flags)
+	);
+
+	/* VIDIOC_QUERYMENU */
+	ioctl(-1, VIDIOC_QUERYMENU, 0);
+	printf("ioctl(-1, %s, NULL)" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_QUERYMENU));
+
+	TAIL_ALLOC_OBJECT_CONST_PTR(struct v4l2_querymenu, p_v4l2_querymenu);
+
+	p_v4l2_querymenu->id = V4L2_CID_EXPOSURE_AUTO;
+	p_v4l2_querymenu->index = 0xdeadbeef;
+
+	ioctl(-1, VIDIOC_QUERYMENU, p_v4l2_querymenu);
+	printf("ioctl(-1, %s, {id=" NABBR("%#x") VERB(" /* ")
+	       NRAW("V4L2_CID_EXPOSURE_AUTO") VERB(" */") ", index=%u"
+	       "})" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_QUERYMENU),
+	       NABBR(p_v4l2_querymenu->id,)
+	       p_v4l2_querymenu->index
 	);
 
 	puts("+++ exited with 0 +++");

--- a/tests/ioctl_v4l2.c
+++ b/tests/ioctl_v4l2.c
@@ -502,7 +502,6 @@ main(void)
 		{ ARG_STR(VIDIOC_OVERLAY) },
 		{ ARG_STR(VIDIOC_G_AUDIO) },
 		{ ARG_STR(VIDIOC_S_AUDIO) },
-		{ ARG_STR(VIDIOC_QUERYMENU) },
 		{ ARG_STR(VIDIOC_G_EDID) },
 		{ ARG_STR(VIDIOC_S_EDID) },
 		{ ARG_STR(VIDIOC_G_OUTPUT) },
@@ -1357,6 +1356,26 @@ main(void)
 	       p_v4l2_expbuf->index,
 	       p_v4l2_expbuf->plane
 	       NABBR(, p_v4l2_expbuf->flags)
+	);
+
+	/* VIDIOC_QUERYMENU */
+	ioctl(-1, VIDIOC_QUERYMENU, 0);
+	printf("ioctl(-1, %s, NULL)" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_QUERYMENU));
+
+	TAIL_ALLOC_OBJECT_CONST_PTR(struct v4l2_querymenu, p_v4l2_querymenu);
+
+	p_v4l2_querymenu->id = V4L2_CID_EXPOSURE_AUTO;
+	p_v4l2_querymenu->index = 42;
+
+	ioctl(-1, VIDIOC_QUERYMENU, p_v4l2_querymenu);
+	printf("ioctl(-1, %s, {"
+	       "id=" NABBR("%#x") VERB(" /* ") NRAW("V4L2_CID_EXPOSURE_AUTO") VERB(" */") ", "
+	       "index=%u"
+	       "})" RVAL_EBADF,
+	       XLAT_STR(VIDIOC_QUERYMENU),
+	       NABBR(p_v4l2_querymenu->id,)
+	       p_v4l2_querymenu->index
 	);
 
 	puts("+++ exited with 0 +++");


### PR DESCRIPTION
Decode the `VIDIOC_QUERYMENU` ioctl, which is used for both string and integer menu controls. Unfortunately without querying the type of the control it is not possible to know if it is a string or integer, so print both.

Integer menus:

  ioctl(3, VIDIOC_QUERYMENU, {id=V4L2_CTRL_CLASS_USER+0xf907, index=2} => {name="\2", value=2}) = 0 <0.000025>

String menus:

  ioctl(3, VIDIOC_QUERYMENU, {id=V4L2_CTRL_CLASS_USER+0xf904, index=1} => {name="Menu Item 1", value=7310548498887107917}) = 0 <0.000039>

* src/v4l2.c: Decode `VIDIOC_QUERYMENU`.
* tests/ioctl_v4l2.c: Remove `VIDIOC_QUERYMENU` from the list of unsupported ioctls, and add some `VIDIOC_EXPBUF` tests.