### PR TITLE
Add support for tracking unknown syscalls in summary mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ Noteworthy changes in release ?.? (????-??-??)
   * Implemented wall-clock-aware columns (wall-total, wall-min, wall-max,
     wall-avg) for the -c/--summary-only report, allowing wall-clock and
     system CPU times to be displayed side by side in a single run.
+  * Included out-of-range syscalls in the -c/--summary-only report.
   * Updated decoding of sched_getattr syscall.
   * Implemented decoding of FS_IOC_SHUTDOWN, PIDFD_GET_INFO, and
     PIDFD_GET_*_NAMESPACE ioctl commands.

--- a/src/count.c
+++ b/src/count.c
@@ -15,6 +15,7 @@
  */
 
 #include "defs.h"
+#include "xstring.h"
 
 #include <stdarg.h>
 
@@ -137,11 +138,138 @@ static const struct {
 	{ "nothing",      CSC_NONE       },
 };
 
+/* Per-unknown syscall stats structure */
+struct unknown_call_counts {
+	kernel_ulong_t scno;
+	char sys_name[sizeof("syscall_0x") + sizeof(kernel_ulong_t) * 2];
+	struct call_counts call_counts;
+};
+
+struct unknown_call_bucket {
+	size_t len;
+	size_t cap;
+	struct unknown_call_counts *entries;
+};
+
+#define UNKNOWN_COUNTS_ENTRIES 16
+
+static struct unknown_call_bucket *unknown_countv[SUPPORTED_PERSONALITIES];
+#define unknown_counts (unknown_countv[current_personality])
+
+static void
+unknown_init_slot(struct call_counts *cc)
+{
+	cc->time_min = max_ts;
+
+	if (summary_needs_wall())
+		cc->wall_time_min = max_ts;
+}
+
+static void
+unknown_init(void)
+{
+	if (unknown_counts)
+		return;
+
+	unknown_counts = xmalloc(sizeof(*unknown_counts));
+
+	unknown_counts->len = 0;
+	unknown_counts->cap = UNKNOWN_COUNTS_ENTRIES;
+	unknown_counts->entries = xcalloc(UNKNOWN_COUNTS_ENTRIES,
+					  sizeof(*unknown_counts->entries));
+
+	for (size_t i = 0; i < UNKNOWN_COUNTS_ENTRIES; i++)
+		unknown_init_slot(&unknown_counts->entries[i].call_counts);
+}
+
+static struct unknown_call_counts *
+get_unknown_by_scno(kernel_ulong_t scno)
+{
+	if (!unknown_counts)
+		return NULL;
+
+	for (size_t i = 0; i < unknown_counts->len; i++)
+		if (unknown_counts->entries[i].scno == scno)
+			return &unknown_counts->entries[i];
+
+	return NULL;
+}
+
+static struct unknown_call_counts *
+get_unknown_by_idx(size_t idx)
+{
+	if (!unknown_counts)
+		return NULL;
+
+	if (idx >= unknown_counts->len)
+		return NULL;
+
+	return &unknown_counts->entries[idx];
+}
+
+static size_t
+get_unknown_bucket_size(void)
+{
+	return unknown_counts ? unknown_counts->len : 0;
+}
+
+static struct call_counts *
+get_syscall_cc(kernel_ulong_t scno)
+{
+	if (scno_in_range(scno))
+		return &counts[scno];
+
+	struct unknown_call_counts *ucc = get_unknown_by_scno(scno);
+	if (!ucc)
+		error_msg_and_die("failed to get unknown syscall"
+				  " counts by %#" PRI_klx " number", scno);
+
+	return &ucc->call_counts;
+}
+
+static const char *
+get_syscall_name(kernel_ulong_t scno)
+{
+	if (scno_in_range(scno))
+		return sysent[scno].sys_name;
+
+	struct unknown_call_counts *ucc = get_unknown_by_scno(scno);
+	if (!ucc)
+		error_msg_and_die("failed to get unknown syscall"
+				  " name by %#" PRI_klx " number", scno);
+
+	return ucc->sys_name;
+}
+
+static void
+unknown_insert(kernel_ulong_t scno)
+{
+	if (get_unknown_by_scno(scno))
+		return;
+
+	unknown_init();
+
+	if (unknown_counts->len == unknown_counts->cap) {
+		unknown_counts->cap *= 2;
+		unknown_counts->entries = xreallocarray(unknown_counts->entries,
+							unknown_counts->cap,
+							sizeof(*unknown_counts->entries));
+
+		for (size_t i = unknown_counts->len; i < unknown_counts->cap; i++)
+			unknown_init_slot(&unknown_counts->entries[i].call_counts);
+	}
+
+	unknown_counts->entries[unknown_counts->len].scno = scno;
+	xsprintf(unknown_counts->entries[unknown_counts->len].sys_name,
+		 "syscall_%#" PRI_klx, shuffle_scno(scno));
+	unknown_counts->len++;
+}
+
 void
 count_syscall(struct tcb *tcp, const struct timespec *syscall_exiting_ts)
 {
 	if (!scno_in_range(tcp->scno))
-		return;
+		unknown_insert(tcp->scno);
 
 	if (!counts) {
 		const bool wall = summary_needs_wall();
@@ -154,7 +282,7 @@ count_syscall(struct tcb *tcp, const struct timespec *syscall_exiting_ts)
 				counts[i].wall_time_min = max_ts;
 		}
 	}
-	struct call_counts *cc = &counts[tcp->scno];
+	struct call_counts *cc = get_syscall_cc(tcp->scno);
 
 	cc->calls++;
 	if (syserror(tcp))
@@ -199,78 +327,101 @@ count_syscall(struct tcb *tcp, const struct timespec *syscall_exiting_ts)
 static int
 time_cmp(const void *a, const void *b)
 {
-	const unsigned int *a_int = a;
-	const unsigned int *b_int = b;
-	return -ts_cmp(&counts[*a_int].time, &counts[*b_int].time);
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+
+	return -ts_cmp(&get_syscall_cc(*a_k)->time,
+		       &get_syscall_cc(*b_k)->time);
 }
 
 static int
 min_time_cmp(const void *a, const void *b)
 {
-	return -ts_cmp(&counts[*((unsigned int *) a)].time_min,
-		       &counts[*((unsigned int *) b)].time_min);
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+
+	return -ts_cmp(&get_syscall_cc(*a_k)->time_min,
+		       &get_syscall_cc(*b_k)->time_min);
 }
 
 static int
 max_time_cmp(const void *a, const void *b)
 {
-	return -ts_cmp(&counts[*((unsigned int *) a)].time_max,
-		       &counts[*((unsigned int *) b)].time_max);
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+
+	return -ts_cmp(&get_syscall_cc(*a_k)->time_max,
+		       &get_syscall_cc(*b_k)->time_max);
 }
 
 static int
 avg_time_cmp(const void *a, const void *b)
 {
-	return -ts_cmp(&counts[*((unsigned int *) a)].time_avg,
-		       &counts[*((unsigned int *) b)].time_avg);
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+
+	return -ts_cmp(&get_syscall_cc(*a_k)->time_avg,
+		       &get_syscall_cc(*b_k)->time_avg);
 }
 
 static int
 wall_time_cmp(const void *a, const void *b)
 {
-	const unsigned int *a_int = a;
-	const unsigned int *b_int = b;
-	return -ts_cmp(&counts[*a_int].wall_time, &counts[*b_int].wall_time);
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+
+	return -ts_cmp(&get_syscall_cc(*a_k)->wall_time,
+		       &get_syscall_cc(*b_k)->wall_time);
 }
 
 static int
 wall_min_time_cmp(const void *a, const void *b)
 {
-	return -ts_cmp(&counts[*((unsigned int *) a)].wall_time_min,
-		       &counts[*((unsigned int *) b)].wall_time_min);
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+
+	return -ts_cmp(&get_syscall_cc(*a_k)->wall_time_min,
+		       &get_syscall_cc(*b_k)->wall_time_min);
 }
 
 static int
 wall_max_time_cmp(const void *a, const void *b)
 {
-	return -ts_cmp(&counts[*((unsigned int *) a)].wall_time_max,
-		       &counts[*((unsigned int *) b)].wall_time_max);
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+
+	return -ts_cmp(&get_syscall_cc(*a_k)->wall_time_max,
+		       &get_syscall_cc(*b_k)->wall_time_max);
 }
 
 static int
 wall_avg_time_cmp(const void *a, const void *b)
 {
-	return -ts_cmp(&counts[*((unsigned int *) a)].wall_time_avg,
-		       &counts[*((unsigned int *) b)].wall_time_avg);
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+
+	return -ts_cmp(&get_syscall_cc(*a_k)->wall_time_avg,
+		       &get_syscall_cc(*b_k)->wall_time_avg);
 }
 
 static int
 syscall_cmp(const void *a, const void *b)
 {
-	const unsigned int *a_int = a;
-	const unsigned int *b_int = b;
-	const char *a_name = sysent[*a_int].sys_name;
-	const char *b_name = sysent[*b_int].sys_name;
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+	const char *a_name = get_syscall_name(*a_k);
+	const char *b_name = get_syscall_name(*b_k);
+
 	return strcmp(a_name ? a_name : "", b_name ? b_name : "");
 }
 
 static int
 count_cmp(const void *a, const void *b)
 {
-	const unsigned int *a_int = a;
-	const unsigned int *b_int = b;
-	uint64_t m = counts[*a_int].calls;
-	uint64_t n = counts[*b_int].calls;
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+	uint64_t m = get_syscall_cc(*a_k)->calls;
+	uint64_t n = get_syscall_cc(*b_k)->calls;
 
 	return (m < n) ? 1 : (m > n) ? -1 : 0;
 }
@@ -278,10 +429,10 @@ count_cmp(const void *a, const void *b)
 static int
 error_cmp(const void *a, const void *b)
 {
-	const unsigned int *a_int = a;
-	const unsigned int *b_int = b;
-	uint64_t m = counts[*a_int].errors;
-	uint64_t n = counts[*b_int].errors;
+	const kernel_ulong_t *a_k = a;
+	const kernel_ulong_t *b_k = b;
+	uint64_t m = get_syscall_cc(*a_k)->errors;
+	uint64_t n = get_syscall_cc(*b_k)->errors;
 
 	return (m < n) ? 1 : (m > n) ? -1 : 0;
 }
@@ -402,68 +553,105 @@ num_chars(const char *fmt, ...)
 	return (unsigned int) MAX(ret, 0);
 }
 
+struct summary_stats {
+	struct timespec tv_cum;
+	const struct timespec *tv_min;
+	const struct timespec *tv_min_max;
+	const struct timespec *tv_max;
+	const struct timespec *tv_avg_max;
+	struct timespec tv_wall_cum;
+	const struct timespec *tv_wall_min;
+	const struct timespec *tv_wall_min_max;
+	const struct timespec *tv_wall_max;
+	const struct timespec *tv_wall_avg_max;
+	uint64_t call_cum;
+	uint64_t error_cum;
+	double float_tv_cum;
+	double float_tv_wall_cum;
+	size_t sc_name_max;
+};
+
+static void
+calc_summary_stats(struct summary_stats *stats, struct call_counts *cc, const char *sys_name)
+{
+	ts_add(&stats->tv_cum, &stats->tv_cum, &cc->time);
+	stats->tv_min = ts_min(stats->tv_min, &cc->time_min);
+	stats->tv_min_max = ts_max(stats->tv_min_max, &cc->time_min);
+	stats->tv_max = ts_max(stats->tv_max, &cc->time_max);
+	if (summary_needs_wall()) {
+		ts_add(&stats->tv_wall_cum, &stats->tv_wall_cum, &cc->wall_time);
+		stats->tv_wall_min = ts_min(stats->tv_wall_min, &cc->wall_time_min);
+		stats->tv_wall_min_max = ts_max(stats->tv_wall_min_max,
+						&cc->wall_time_min);
+		stats->tv_wall_max = ts_max(stats->tv_wall_max,
+					&cc->wall_time_max);
+		ts_div(&cc->wall_time_avg, &cc->wall_time,
+			cc->calls);
+		stats->tv_wall_avg_max = ts_max(stats->tv_wall_avg_max,
+						&cc->wall_time_avg);
+	}
+	stats->call_cum += cc->calls;
+	stats->error_cum += cc->errors;
+
+	ts_div(&cc->time_avg, &cc->time, cc->calls);
+	stats->tv_avg_max = ts_max(stats->tv_avg_max, &cc->time_avg);
+
+	stats->sc_name_max = MAX(stats->sc_name_max, strlen(sys_name));
+}
+
 static void
 call_summary_pers(FILE *outf)
 {
-	unsigned int *indices;
+	/*
+	 * unknown system calls start at index nsyscalls
+	 * and their index may differ from their number
+	 */
+	kernel_ulong_t *indices;
+	size_t indices_size = nsyscalls + get_unknown_bucket_size();
 	size_t last_column = 0;
 
-	struct timespec tv_cum = zero_ts;
-	const struct timespec *tv_min = &max_ts;
-	const struct timespec *tv_min_max = &zero_ts;
-	const struct timespec *tv_max = &zero_ts;
-	const struct timespec *tv_avg_max = &zero_ts;
-	struct timespec tv_wall_cum = zero_ts;
-	const struct timespec *tv_wall_min = &max_ts;
-	const struct timespec *tv_wall_min_max = &zero_ts;
-	const struct timespec *tv_wall_max = &zero_ts;
-	const struct timespec *tv_wall_avg_max = &zero_ts;
-	uint64_t call_cum = 0;
-	uint64_t error_cum = 0;
+	struct summary_stats stats = {
+		.tv_cum      	 = zero_ts,
+		.tv_min      	 = &max_ts,
+		.tv_min_max  	 = &zero_ts,
+		.tv_max      	 = &zero_ts,
+		.tv_avg_max  	 = &zero_ts,
+		.tv_wall_cum 	 = zero_ts,
+		.tv_wall_min 	 = &max_ts,
+		.tv_wall_min_max = &zero_ts,
+		.tv_wall_max 	 = &zero_ts,
+		.tv_wall_avg_max = &zero_ts,
+		.call_cum    	 = 0,
+		.error_cum   	 = 0,
+		.sc_name_max 	 = 0
+	};
 
-	double float_tv_cum;
-	double float_tv_wall_cum;
-	double percent;
-
-	size_t sc_name_max = 0;
-
-
-	/* sort, calculate statistics */
-	indices = xcalloc(nsyscalls, sizeof(indices[0]));
+	/* sort, calculate statistics (for known syscalls) */
+	indices = xcalloc(indices_size, sizeof(indices[0]));
 	for (size_t i = 0; i < nsyscalls; ++i) {
 		indices[i] = i;
 		if (counts[i].calls == 0)
 			continue;
 
-		ts_add(&tv_cum, &tv_cum, &counts[i].time);
-		tv_min = ts_min(tv_min, &counts[i].time_min);
-		tv_min_max = ts_max(tv_min_max, &counts[i].time_min);
-		tv_max = ts_max(tv_max, &counts[i].time_max);
-		if (summary_needs_wall()) {
-			ts_add(&tv_wall_cum, &tv_wall_cum, &counts[i].wall_time);
-			tv_wall_min = ts_min(tv_wall_min, &counts[i].wall_time_min);
-			tv_wall_min_max = ts_max(tv_wall_min_max,
-						 &counts[i].wall_time_min);
-			tv_wall_max = ts_max(tv_wall_max,
-					     &counts[i].wall_time_max);
-			ts_div(&counts[i].wall_time_avg, &counts[i].wall_time,
-			       counts[i].calls);
-			tv_wall_avg_max = ts_max(tv_wall_avg_max,
-						 &counts[i].wall_time_avg);
-		}
-		call_cum += counts[i].calls;
-		error_cum += counts[i].errors;
-
-		ts_div(&counts[i].time_avg, &counts[i].time, counts[i].calls);
-		tv_avg_max = ts_max(tv_avg_max, &counts[i].time_avg);
-
-		sc_name_max = MAX(sc_name_max, strlen(sysent[i].sys_name));
+		calc_summary_stats(&stats, &counts[i], sysent[i].sys_name);
 	}
-	float_tv_cum = ts_float(&tv_cum);
-	float_tv_wall_cum = summary_needs_wall() ? ts_float(&tv_wall_cum) : 0;
+
+	/* for unknown syscalls */
+	for (size_t i = 0; i < get_unknown_bucket_size(); ++i) {
+		struct unknown_call_counts *ucc = get_unknown_by_idx(i);
+		struct call_counts *cc = &ucc->call_counts;
+
+		indices[nsyscalls + i] = ucc->scno;
+
+		calc_summary_stats(&stats, cc, ucc->sys_name);
+	}
+
+	stats.float_tv_cum = ts_float(&stats.tv_cum);
+	stats.float_tv_wall_cum = summary_needs_wall()
+				  ? ts_float(&stats.tv_wall_cum) : 0;
 
 	if (sortfun)
-		qsort((void *) indices, nsyscalls, sizeof(indices[0]), sortfun);
+		qsort((void *) indices, indices_size, sizeof(indices[0]), sortfun);
 
 	enum column_flags {
 		CF_L = 1 << 0, /* Left-aligned column */
@@ -501,28 +689,28 @@ call_summary_pers(FILE *outf)
 #define W_(c_, v_) [c_] = MAX(cdesc[c_].sz, (v_))
 	unsigned int cwidths[CSC_MAX] = {
 		W_(CSC_TIME_100S,  sizeof("100.00") - 1),
-		W_(CSC_TIME_TOTAL, num_chars("%.6f", float_tv_cum)),
+		W_(CSC_TIME_TOTAL, num_chars("%.6f", stats.float_tv_cum)),
 		W_(CSC_TIME_MIN,   num_chars("%" PRId64 ".000000",
-					     (int64_t) tv_min_max->tv_sec)),
+					     (int64_t) stats.tv_min_max->tv_sec)),
 		W_(CSC_TIME_MAX,   num_chars("%" PRId64 ".000000",
-					     (int64_t) tv_max->tv_sec)),
+					     (int64_t) stats.tv_max->tv_sec)),
 		W_(CSC_TIME_AVG,   num_chars("%" PRId64 ,
-					     (uint64_t) (ts_float(tv_avg_max)
+					     (uint64_t) (ts_float(stats.tv_avg_max)
 							 * 1e6))),
-		W_(CSC_CALLS,      num_chars("%" PRIu64, call_cum)),
-		W_(CSC_ERRORS,     num_chars("%" PRIu64, error_cum)),
-		W_(CSC_SC_NAME,    sc_name_max + 1),
+		W_(CSC_CALLS,      num_chars("%" PRIu64, stats.call_cum)),
+		W_(CSC_ERRORS,     num_chars("%" PRIu64, stats.error_cum)),
+		W_(CSC_SC_NAME,    stats.sc_name_max + 1),
 		W_(CSC_TIME_WALL_TOTAL,
-		   num_chars("%.6f", float_tv_wall_cum)),
+		   num_chars("%.6f", stats.float_tv_wall_cum)),
 		W_(CSC_TIME_WALL_MIN,
 		   num_chars("%" PRId64 ".000000",
-			     (int64_t) tv_wall_min_max->tv_sec)),
+			     (int64_t) stats.tv_wall_min_max->tv_sec)),
 		W_(CSC_TIME_WALL_MAX,
 		   num_chars("%" PRId64 ".000000",
-			     (int64_t) tv_wall_max->tv_sec)),
+			     (int64_t) stats.tv_wall_max->tv_sec)),
 		W_(CSC_TIME_WALL_AVG,
 		   num_chars("%" PRId64,
-			     (uint64_t) (ts_float(tv_wall_avg_max) * 1e6))),
+			     (uint64_t) (ts_float(stats.tv_wall_avg_max) * 1e6))),
 	};
 #undef W_
 
@@ -583,10 +771,12 @@ call_summary_pers(FILE *outf)
 	}
 
 	/* data output */
-	for (size_t j = 0; j < nsyscalls; ++j) {
-		unsigned int idx = indices[j];
-		struct call_counts *cc = &counts[idx];
+	for (size_t j = 0; j < indices_size; ++j) {
+		kernel_ulong_t idx = indices[j];
+		struct call_counts *cc = get_syscall_cc(idx);
+		const char *sys_name = get_syscall_name(idx);
 		double float_syscall_time;
+		double percent;
 
 		if (cc->calls == 0)
 			continue;
@@ -595,7 +785,7 @@ call_summary_pers(FILE *outf)
 		percent = (100.0 * float_syscall_time);
 		/* else: float_tv_cum can be 0.0 too and we get 0/0 = NAN */
 		if (percent != 0.0)
-			   percent /= float_tv_cum;
+			percent /= stats.float_tv_cum;
 
 		for (size_t i = 0; i <= last_column; ++i) {
 			const size_t c = columns[i];
@@ -611,7 +801,7 @@ call_summary_pers(FILE *outf)
 			    (uint64_t) (ts_float(&cc->time_avg) * 1e6));
 			PC_(CSC_CALLS,      cc->calls);
 			PC_(CSC_ERRORS,     cc->errors);
-			PC_(CSC_SC_NAME,    sysent[idx].sys_name);
+			PC_(CSC_SC_NAME,    sys_name);
 			PC_(CSC_TIME_WALL_TOTAL, ts_float(&cc->wall_time));
 			PC_(CSC_TIME_WALL_MIN,   ts_float(&cc->wall_time_min));
 			PC_(CSC_TIME_WALL_MAX,   ts_float(&cc->wall_time_max));
@@ -643,18 +833,18 @@ call_summary_pers(FILE *outf)
 
 		switch (c) {
 		PC_(CSC_TIME_100S, 100.0);
-		PC_(CSC_TIME_TOTAL, float_tv_cum);
-		PC_(CSC_TIME_MIN, ts_float(tv_min));
-		PC_(CSC_TIME_MAX, ts_float(tv_max));
-		PC_(CSC_TIME_AVG, (uint64_t) (float_tv_cum / call_cum * 1e6));
-		PC_(CSC_CALLS, call_cum);
-		PC_(CSC_ERRORS, error_cum);
+		PC_(CSC_TIME_TOTAL, stats.float_tv_cum);
+		PC_(CSC_TIME_MIN, ts_float(stats.tv_min));
+		PC_(CSC_TIME_MAX, ts_float(stats.tv_max));
+		PC_(CSC_TIME_AVG, (uint64_t) (stats.float_tv_cum / stats.call_cum * 1e6));
+		PC_(CSC_CALLS, stats.call_cum);
+		PC_(CSC_ERRORS, stats.error_cum);
 		PC_(CSC_SC_NAME, "total");
-		PC_(CSC_TIME_WALL_TOTAL, float_tv_wall_cum);
-		PC_(CSC_TIME_WALL_MIN, ts_float(tv_wall_min));
-		PC_(CSC_TIME_WALL_MAX, ts_float(tv_wall_max));
+		PC_(CSC_TIME_WALL_TOTAL, stats.float_tv_wall_cum);
+		PC_(CSC_TIME_WALL_MIN, ts_float(stats.tv_wall_min));
+		PC_(CSC_TIME_WALL_MAX, ts_float(stats.tv_wall_max));
 		PC_(CSC_TIME_WALL_AVG,
-		    (uint64_t) (float_tv_wall_cum / call_cum * 1e6));
+		    (uint64_t) (stats.float_tv_wall_cum / stats.call_cum * 1e6));
 		}
 	}
 	fputc('\n', outf);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -89,6 +89,9 @@ clone_ptrace-qq
 close_range
 copy_file_range
 count-f
+count_unknown
+count_unknown_many
+count_unknown_mixed
 creat
 delay
 delete_module

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -142,6 +142,9 @@ check_PROGRAMS = $(PURE_EXECUTABLES) \
 	clone_ptrace-qq \
 	close_range \
 	count-f \
+	count_unknown \
+	count_unknown_many \
+	count_unknown_mixed \
 	delay \
 	detach-vfork \
 	env-i \
@@ -644,6 +647,11 @@ MISC_TESTS = \
 	bexecve.test \
 	clone_ptrace.test \
 	count-f.test \
+	count_unknown.test \
+	count_unknown-S.test \
+	count_unknown-wall.test \
+	count_unknown_many.test \
+	count_unknown_mixed.test \
 	delay.test \
 	detach-running.test \
 	detach-sleeping.test \
@@ -891,6 +899,7 @@ EXTRA_DIST = \
 	lstatx.c \
 	nlattr_ifla.h \
 	nlattr_ifla_af_inet6.h \
+	nsyscalls.h \
 	print_user_desc.c \
 	printsignal.c \
 	printxval.c \

--- a/tests/count_unknown-S.test
+++ b/tests/count_unknown-S.test
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Check that -S sorting works for out-of-range syscalls in -c summary.
+#
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+NAME=count_unknown
+
+if [ "$MIPS_ABI" = "o32" ]; then
+	skip_ "mips $MIPS_ABI is not supported by this test yet"
+fi
+
+test_unknown_sort()
+{
+	local sortby sortopts sedexpr
+	sortby="$1"; shift
+	sortopts="$1"; shift
+	sedexpr="$1"; shift
+
+	run_prog > /dev/null
+	run_strace -e trace=none -c $sortby "$@" $args > /dev/null
+	[ -s "$LOG" ] ||
+		dump_log_and_fail_with "$STRACE $args produced no output"
+
+	check_prog sed
+	sed -E -n -e "$sedexpr" < "$LOG" > "$OUT"
+	[ -s "$OUT" ] ||
+		dump_log_and_fail_with "sed -E -n -e \"$sedexpr\" produced no output"
+
+	LC_ALL=C sort -c $sortopts "$OUT" ||
+		dump_log_and_fail_with "$STRACE $args output not sorted properly"
+}
+
+s='[[:space:]]+'
+c="$s([^[:space:]]+)"
+d='[0-9]'
+
+test_unknown_sort '-S total_time' '-g -r' \
+	"/^$s$d/ s/^$c$s.*/\1/p"
+
+test_unknown_sort '-S wall-total' '-g -r' \
+	"/^$s$d/ s/^$c$c$s.*/\2/p" \
+	-U time,wall-total,calls,errors,syscall
+
+test_unknown_sort '-S avg_time' '-n -r' \
+	"/^$s$d/ s/^$c$c$c$s.*/\3/p"
+
+test_unknown_sort '-S calls' '-n -r' \
+	"/^$s$d/ s/^$c$c$c$c$s.*/\4/p"
+
+test_unknown_sort '-S error' '-n -r' \
+	"/^$s$d/ s/^$c$c$c$c$c$s.*/\5/p"
+
+test_unknown_sort '-S syscall_name' '' \
+	"/^$s$d/ s/^$c$c$c$c$c$c\$/\6/p"

--- a/tests/count_unknown-wall.test
+++ b/tests/count_unknown-wall.test
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# Check that -c wall columns work for out-of-range syscalls.
+#
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+NAME=count_unknown
+
+if [ "$MIPS_ABI" = "o32" ]; then
+	skip_ "mips $MIPS_ABI is not supported by this test yet"
+fi
+
+run_prog > /dev/null
+
+run_strace -e trace=none -c \
+	-U 'time,wall-total,wall-min,wall-max,wall-avg,calls,errors,syscall' \
+	$args > "$OUT"
+
+check_prog awk
+awk '
+BEGIN {
+	f["time"] = 1
+	f["wall-total"] = 2
+	f["wall-min"] = 3
+	f["wall-max"] = 4
+	d["wall-avg"] = 5
+	d["calls"] = 6
+	d["errors"] = 7
+}
+$NF ~ /^syscall_0x/ {
+	found=1
+	for (i in f) {
+		v=$f[i]
+		if (v !~ /^[0-9]+\.[0-9]+$/) {
+			printf("invalid %s for %s: %s\n", i, $NF, v) > "/dev/stderr"
+			exit 1
+		}
+	}
+	for (i in d) {
+		v=$d[i]
+		if (v !~ /^[0-9]+$/) {
+			printf("invalid %s for %s: %s\n", i, $NF, v) > "/dev/stderr"
+			exit 1
+		}
+	}
+}
+END {
+	if (found != 1) {
+		print "summary lines for out-of-range syscalls not found" > "/dev/stderr"
+		exit 1
+	}
+}
+' "$LOG" ||
+	dump_log_and_fail_with "$STRACE $args: output does not meet expectations"

--- a/tests/count_unknown.c
+++ b/tests/count_unknown.c
@@ -1,0 +1,28 @@
+/*
+ * Check that -c accounts for out-of-range syscalls in the summary.
+ *
+ * Copyright (c) 2026 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "nsyscalls.h"
+
+int
+main(void)
+{
+	const unsigned long scno1 = ARRAY_SIZE(syscallent);
+	const unsigned long scno2 = scno1 + 1;
+
+	(void) invoke_syscall(scno1);
+	(void) invoke_syscall(scno2);
+	(void) invoke_syscall(scno1);
+
+	printf("syscall_%#lx\n", scno1 | SYSCALL_BIT);
+	printf("syscall_%#lx\n", scno2 | SYSCALL_BIT);
+
+	(void) syscallent;	/* workaround for clang bug #33068 */
+
+	return 0;
+}

--- a/tests/count_unknown.test
+++ b/tests/count_unknown.test
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Check that -c accounts for out-of-range syscalls in the summary.
+#
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+if [ "$MIPS_ABI" = "o32" ]; then
+	skip_ "mips $MIPS_ABI is not supported by this test yet"
+fi
+
+run_prog > "$OUT"
+
+cat > "$EXP" << '__EOF__'
+% time     seconds  usecs/call     calls    errors syscall
+------ ----------- ----------- --------- --------- ----------------
+100.00 +[^ ]+ +[^ ]+ +3 +3 +total
+__EOF__
+
+check_prog sed
+sed -e '1s/^/[ ]*[^ ]+ +[^ ]+ +[^ ]+ +2 +2 +/' \
+    -e '2s/^/[ ]*[^ ]+ +[^ ]+ +[^ ]+ +1 +1 +/' < "$OUT" >> "$EXP"
+
+run_strace -e trace=none -c $args > /dev/null
+
+match_grep "$LOG" "$EXP"

--- a/tests/count_unknown_many.c
+++ b/tests/count_unknown_many.c
@@ -1,0 +1,25 @@
+/*
+ * Check that -c accounts for many distinct out-of-range syscalls.
+ *
+ * Copyright (c) 2026 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "nsyscalls.h"
+
+int
+main(void)
+{
+	for (unsigned i = 0; i < 17; i++) {
+		const unsigned long scno = ARRAY_SIZE(syscallent) + i;
+
+		(void) invoke_syscall(scno);
+		printf("syscall_%#lx\n", scno | SYSCALL_BIT);
+	}
+
+	(void) syscallent;	/* workaround for clang bug #33068 */
+
+	return 0;
+}

--- a/tests/count_unknown_many.test
+++ b/tests/count_unknown_many.test
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# Check that -c accounts for many distinct out-of-range syscalls.
+#
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+if [ "$MIPS_ABI" = "o32" ]; then
+	skip_ "mips $MIPS_ABI is not supported by this test yet"
+fi
+
+run_prog > "$OUT"
+
+cat > "$EXP" << '__EOF__'
+% time     seconds  usecs/call     calls    errors syscall
+------ ----------- ----------- --------- --------- ----------------
+100.00 +[^ ]+ +[^ ]+ +17 +17 +total
+__EOF__
+
+check_prog sed
+sed 's/^/[ ]*[^ ]+ +[^ ]+ +[^ ]+ +1 +1 +/' < "$OUT" >> "$EXP"
+
+run_strace -e trace=none -c $args > /dev/null
+
+match_grep "$LOG" "$EXP"

--- a/tests/count_unknown_mixed.c
+++ b/tests/count_unknown_mixed.c
@@ -1,0 +1,24 @@
+/*
+ * Check that -c summary includes both known and unknown syscalls.
+ *
+ * Copyright (c) 2026 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "nsyscalls.h"
+
+int
+main(void)
+{
+	const unsigned long scno = ARRAY_SIZE(syscallent);
+
+	(void) invoke_syscall(scno);
+	(void) syscall(__NR_getpid);
+
+	printf("syscall_%#lx\n", scno | SYSCALL_BIT);
+	printf("getpid\n");
+
+	return 0;
+}

--- a/tests/count_unknown_mixed.test
+++ b/tests/count_unknown_mixed.test
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Check that -c summary includes both known and unknown syscalls.
+#
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+if [ "$MIPS_ABI" = "o32" ]; then
+	skip_ "mips $MIPS_ABI is not supported by this test yet"
+fi
+
+run_prog > "$OUT"
+
+cat > "$EXP" << '__EOF__'
+% time     seconds  usecs/call     calls    errors syscall
+------ ----------- ----------- --------- --------- ----------------
+100.00 +[^ ]+ +[^ ]+ +2 +1 +total
+__EOF__
+
+check_prog sed
+sed -e '1s/^/[ ]*[^ ]+ +[^ ]+ +[^ ]+ +1 +1 +/' \
+    -e '2s/^/[ ]*[^ ]+ +[^ ]+ +[^ ]+ +1 +/' < "$OUT" >> "$EXP"
+
+run_strace -e trace=getpid -c $args > /dev/null
+
+match_grep "$LOG" "$EXP"

--- a/tests/nsyscalls.c
+++ b/tests/nsyscalls.c
@@ -8,21 +8,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#include "tests.h"
-#include "sysent.h"
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include "scno.h"
-
-#include "sysent_shorthand_defs.h"
-
-static const struct_sysent syscallent[] = {
-#include "syscallent.h"
-};
-
-#include "sysent_shorthand_undefs.h"
+#include "nsyscalls.h"
 
 #ifndef DEBUG_PRINT
 # define DEBUG_PRINT 0
@@ -36,17 +22,7 @@ static FILE *debug_out;
 static void
 test_syscall(const unsigned long nr)
 {
-	static const kernel_ulong_t a[] = {
-		(kernel_ulong_t) 0xface0fedbadc0dedULL,
-		(kernel_ulong_t) 0xface1fedbadc1dedULL,
-		(kernel_ulong_t) 0xface2fedbadc2dedULL,
-		(kernel_ulong_t) 0xface3fedbadc3dedULL,
-		(kernel_ulong_t) 0xface4fedbadc4dedULL,
-		(kernel_ulong_t) 0xface5fedbadc5dedULL
-	};
-
-	long rc = syscall(nr | SYSCALL_BIT,
-			  a[0], a[1], a[2], a[3], a[4], a[5]);
+	long rc = invoke_syscall(nr);
 
 #if DEBUG_PRINT
 	fprintf(debug_out, "%s: pid %d invalid syscall %#lx\n",
@@ -56,16 +32,22 @@ test_syscall(const unsigned long nr)
 #ifdef LINUX_MIPSO32
 	printf("syscall(%#lx, %#lx, %#lx, %#lx, %#lx, %#lx, %#lx)"
 	       " = %s\n", nr | SYSCALL_BIT,
-	       a[0], a[1], a[2], a[3], a[4], a[5], sprintrc(rc));
+	       out_of_range_syscall_args[0],
+	       out_of_range_syscall_args[1],
+	       out_of_range_syscall_args[2],
+	       out_of_range_syscall_args[3],
+	       out_of_range_syscall_args[4],
+	       out_of_range_syscall_args[5],
+	       sprintrc(rc));
 #else
 	printf("syscall_%#lx(%#llx, %#llx, %#llx, %#llx, %#llx, %#llx)"
 	       " = %s\n", nr | SYSCALL_BIT,
-	       (unsigned long long) a[0],
-	       (unsigned long long) a[1],
-	       (unsigned long long) a[2],
-	       (unsigned long long) a[3],
-	       (unsigned long long) a[4],
-	       (unsigned long long) a[5],
+	       (unsigned long long) out_of_range_syscall_args[0],
+	       (unsigned long long) out_of_range_syscall_args[1],
+	       (unsigned long long) out_of_range_syscall_args[2],
+	       (unsigned long long) out_of_range_syscall_args[3],
+	       (unsigned long long) out_of_range_syscall_args[4],
+	       (unsigned long long) out_of_range_syscall_args[5],
 	       sprintrc(rc));
 #endif
 }

--- a/tests/nsyscalls.h
+++ b/tests/nsyscalls.h
@@ -1,0 +1,46 @@
+/*
+ * Helper header for out-of-range syscalls decoding checks.
+ *
+ * Copyright (c) 2015-2026 Dmitry V. Levin <ldv@strace.io>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "tests.h"
+#include "sysent.h"
+#include "scno.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "sysent_shorthand_defs.h"
+
+static const struct_sysent syscallent[] = {
+#include "syscallent.h"
+};
+
+#include "sysent_shorthand_undefs.h"
+
+static const kernel_ulong_t out_of_range_syscall_args[] = {
+	(kernel_ulong_t) 0xface0fedbadc0dedULL,
+	(kernel_ulong_t) 0xface1fedbadc1dedULL,
+	(kernel_ulong_t) 0xface2fedbadc2dedULL,
+	(kernel_ulong_t) 0xface3fedbadc3dedULL,
+	(kernel_ulong_t) 0xface4fedbadc4dedULL,
+	(kernel_ulong_t) 0xface5fedbadc5dedULL
+};
+
+static long
+invoke_syscall(const unsigned long nr)
+{
+	return syscall(nr | SYSCALL_BIT,
+		       out_of_range_syscall_args[0],
+		       out_of_range_syscall_args[1],
+		       out_of_range_syscall_args[2],
+		       out_of_range_syscall_args[3],
+		       out_of_range_syscall_args[4],
+		       out_of_range_syscall_args[5]);
+}


### PR DESCRIPTION
Related to issue #319 

This patch introduces support for unknown syscalls tracking in summary mode (-c/-C).
It prepares the codebase for integrating unknown syscall accounting into statistics output.

Previously, syscalls with unknown numbers were ignored in summary mode, resulting in incomplete statistics.
This change adds a separate dynamic bucket for unknown syscalls and the necessary tracking logic.
No changes to output formatting or final statistics aggregation are included yet.

Changes:
- Add unknown syscall tracking infrastructure (src/count.c)
- Introduce unknown syscall storage (src/unknown_count.c)
- Add public declarations (src/count.h)