### PR TITLE
fix: add explicit cast for bsearch() return with glibc 2.43 / C23

### DIFF
--- a/src/ioctl.c
+++ b/src/ioctl.c
@@ -49,8 +49,8 @@ ioctl_lookup(const unsigned int code)
 {
 	const struct_ioctlent *iop;
 
-	iop = bsearch((const void *) (const uintptr_t) code, ioctlent,
-			nioctlents, sizeof(ioctlent[0]), compare);
+	iop = (const struct_ioctlent *) bsearch((const void *) (uintptr_t) code,
+			ioctlent, nioctlents, sizeof(ioctlent[0]), compare);
 	while (iop > ioctlent) {
 		iop--;
 		if (iop->code != code) {


### PR DESCRIPTION
## Summary

Fixes #380 — glibc 2.43 declares `bsearch()` as returning `const void *` under C23 mode, causing a "discards const qualifier" error when assigning to `const struct_ioctlent *` without an explicit cast.

## Changes

`src/ioctl.c`: Add explicit `(const struct_ioctlent *)` cast on the `bsearch()` return value in `ioctl_lookup()`.

## Error (before fix)

```
src/ioctl.c: In function 'ioctl_lookup':
src/ioctl.c:52:13: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
   52 | iop = bsearch((const void *) (const uintptr_t) code, ioctlent,
      | ^
```

## Notes

- The same `bsearch()` call in `src/xlat.c` (line 89) does not need a fix — its target variable is already `const struct xlat_data *` and the const-qualified return from glibc 2.43's `bsearch()` is compatible without a cast.
- Also removed the unnecessary `const` from `(const uintptr_t)` — `uintptr_t` is not const-qualified so the cast is misleading.