### PR TITLE
count: add wall-* column aliases for -c summary report

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ Noteworthy changes in release ?.? (????-??-??)
 ===============================================
 
 * Improvements
+  * Implemented wall-clock-aware columns (wall-total, wall-min, wall-max,
+    wall-avg) for the -c/--summary-only report, allowing wall-clock and
+    system CPU times to be displayed side by side in a single run.
   * Updated decoding of sched_getattr syscall.
   * Implemented decoding of FS_IOC_SHUTDOWN, PIDFD_GET_INFO, and
     PIDFD_GET_*_NAMESPACE ioctl commands.

--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -1508,6 +1508,23 @@ Maximum observed call duration.
 .BR avg\-time " (or " time\-avg )
 Average call duration.
 .TQ
+.BR wall\-total " (or " total\-wall )
+Total wall-clock time consumed by a specific system call.  Always wall-clock,
+regardless of the
+.B \-w
+option, allowing it to be displayed alongside
+.B total\-time
+in a single run.
+.TQ
+.BR wall\-min " (or " min\-wall )
+Minimum observed wall-clock call duration.
+.TQ
+.BR wall\-max " (or " max\-wall )
+Maximum observed wall-clock call duration.
+.TQ
+.BR wall\-avg " (or " avg\-wall )
+Average wall-clock call duration.
+.TQ
 .BR calls " (or " count )
 Call count.
 .TQ

--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -1452,6 +1452,8 @@ This is useful for overriding the default heuristic, which estimates the time
 spent in the measurement process itself when timing system calls with the
 .B \-c
 option.
+The same overhead is subtracted from polymorphic time columns and from
+.BR wall\-total ", " wall\-min ", " wall\-max ", and " wall\-avg .
 The accuracy of the heuristic can be gauged by timing a given program run
 without tracing (using
 .BR time (1))
@@ -1474,6 +1476,10 @@ Valid values are
 .BR min\-time " (or " shortest " or " time\-min ),
 .BR max\-time " (or " longest " or " time\-max ),
 .BR avg\-time " (or " time\-avg ),
+.BR wall\-total " (or " total\-wall ),
+.BR wall\-min " (or " min\-wall ),
+.BR wall\-max " (or " max\-wall ),
+.BR wall\-avg " (or " avg\-wall ),
 .BR calls " (or " count ),
 .BR errors " (or " error ),
 .BR name " (or " syscall " or " syscall\-name ),
@@ -1500,13 +1506,13 @@ Total system (or wall clock, if
 option is provided) time consumed by a specific system call.
 .TQ
 .BR min\-time " (or " shortest " or " time\-min )
-Minimum observed call duration.
+Minimum observed call duration in seconds.
 .TQ
 .BR max\-time " (or " longest " or " time\-max )
-Maximum observed call duration.
+Maximum observed call duration in seconds.
 .TQ
 .BR avg\-time " (or " time\-avg )
-Average call duration.
+Average call duration in microseconds per call.
 .TQ
 .BR wall\-total " (or " total\-wall )
 Total wall-clock time consumed by a specific system call.  Always wall-clock,
@@ -1517,13 +1523,13 @@ option, allowing it to be displayed alongside
 in a single run.
 .TQ
 .BR wall\-min " (or " min\-wall )
-Minimum observed wall-clock call duration.
+Minimum observed wall-clock call duration in seconds.
 .TQ
 .BR wall\-max " (or " max\-wall )
-Maximum observed wall-clock call duration.
+Maximum observed wall-clock call duration in seconds.
 .TQ
 .BR wall\-avg " (or " avg\-wall )
-Average wall-clock call duration.
+Average wall-clock call duration in microseconds per call.
 .TQ
 .BR calls " (or " count )
 Call count.

--- a/src/count.c
+++ b/src/count.c
@@ -42,6 +42,8 @@ static const struct timespec max_ts = {
 
 static struct timespec overhead;
 
+static bool summary_wall_columns;
+static bool summary_sortby_wall;
 
 enum count_summary_columns {
 	CSC_NONE,
@@ -60,6 +62,18 @@ enum count_summary_columns {
 
 	CSC_MAX,
 };
+
+static bool
+summary_needs_wall(void)
+{
+	return summary_wall_columns || summary_sortby_wall;
+}
+
+static bool
+column_is_wall(uint8_t column)
+{
+	return column >= CSC_TIME_WALL_TOTAL && column <= CSC_TIME_WALL_AVG;
+}
 
 static uint8_t columns[CSC_MAX] = {
 	CSC_TIME_100S,
@@ -130,11 +144,14 @@ count_syscall(struct tcb *tcp, const struct timespec *syscall_exiting_ts)
 		return;
 
 	if (!counts) {
+		const bool wall = summary_needs_wall();
+
 		counts = xcalloc(nsyscalls, sizeof(*counts));
 
 		for (size_t i = 0; i < nsyscalls; i++) {
 			counts[i].time_min = max_ts;
-			counts[i].wall_time_min = max_ts;
+			if (wall)
+				counts[i].wall_time_min = max_ts;
 		}
 	}
 	struct call_counts *cc = &counts[tcp->scno];
@@ -160,11 +177,19 @@ count_syscall(struct tcb *tcp, const struct timespec *syscall_exiting_ts)
 	cc->time_min = *ts_min(&cc->time_min, wts_nonneg);
 	cc->time_max = *ts_max(&cc->time_max, wts_nonneg);
 
-	struct timespec wall_wts;
-	ts_sub(&wall_wts, syscall_exiting_ts, &tcp->etime);
-	ts_sub(&wall_wts, &wall_wts, &overhead);
+	if (!summary_needs_wall())
+		return;
 
-	const struct timespec *wall_wts_nonneg = ts_max(&wall_wts, &zero_ts);
+	struct timespec wall_wts;
+	const struct timespec *wall_wts_nonneg;
+
+	if (count_wallclock) {
+		wall_wts_nonneg = wts_nonneg;
+	} else {
+		ts_sub(&wall_wts, syscall_exiting_ts, &tcp->etime);
+		ts_sub(&wall_wts, &wall_wts, &overhead);
+		wall_wts_nonneg = ts_max(&wall_wts, &zero_ts);
+	}
 
 	ts_add(&cc->wall_time, &cc->wall_time, wall_wts_nonneg);
 	cc->wall_time_min = *ts_min(&cc->wall_time_min, wall_wts_nonneg);
@@ -282,9 +307,14 @@ set_sortby(const char *sortby)
 		[CSC_TIME_WALL_AVG]   = wall_avg_time_cmp,
 	};
 
+	summary_sortby_wall = false;
+
 	for (size_t i = 0; i < ARRAY_SIZE(column_aliases); ++i) {
 		if (!strcmp(column_aliases[i].name, sortby)) {
-			sortfun = sort_fns[column_aliases[i].column];
+			const uint8_t column = column_aliases[i].column;
+
+			sortfun = sort_fns[column];
+			summary_sortby_wall = column_is_wall(column);
 			return;
 		}
 	}
@@ -300,6 +330,7 @@ set_count_summary_columns(const char *s)
 	size_t cur = 0;
 
 	memset(columns, 0, sizeof(columns));
+	summary_wall_columns = false;
 
 	for (;;) {
 		bool found = false;
@@ -344,6 +375,13 @@ set_count_summary_columns(const char *s)
 	 */
 	if (!visible[CSC_SC_NAME])
 		columns[cur++] = CSC_SC_NAME;
+
+	for (size_t i = 0; i < ARRAY_SIZE(columns) && columns[i]; ++i) {
+		if (column_is_wall(columns[i])) {
+			summary_wall_columns = true;
+			break;
+		}
+	}
 }
 
 int
@@ -401,25 +439,28 @@ call_summary_pers(FILE *outf)
 		tv_min = ts_min(tv_min, &counts[i].time_min);
 		tv_min_max = ts_max(tv_min_max, &counts[i].time_min);
 		tv_max = ts_max(tv_max, &counts[i].time_max);
-		ts_add(&tv_wall_cum, &tv_wall_cum, &counts[i].wall_time);
-		tv_wall_min = ts_min(tv_wall_min, &counts[i].wall_time_min);
-		tv_wall_min_max = ts_max(tv_wall_min_max,
-					 &counts[i].wall_time_min);
-		tv_wall_max = ts_max(tv_wall_max, &counts[i].wall_time_max);
+		if (summary_needs_wall()) {
+			ts_add(&tv_wall_cum, &tv_wall_cum, &counts[i].wall_time);
+			tv_wall_min = ts_min(tv_wall_min, &counts[i].wall_time_min);
+			tv_wall_min_max = ts_max(tv_wall_min_max,
+						 &counts[i].wall_time_min);
+			tv_wall_max = ts_max(tv_wall_max,
+					     &counts[i].wall_time_max);
+			ts_div(&counts[i].wall_time_avg, &counts[i].wall_time,
+			       counts[i].calls);
+			tv_wall_avg_max = ts_max(tv_wall_avg_max,
+						 &counts[i].wall_time_avg);
+		}
 		call_cum += counts[i].calls;
 		error_cum += counts[i].errors;
 
 		ts_div(&counts[i].time_avg, &counts[i].time, counts[i].calls);
 		tv_avg_max = ts_max(tv_avg_max, &counts[i].time_avg);
-		ts_div(&counts[i].wall_time_avg, &counts[i].wall_time,
-		       counts[i].calls);
-		tv_wall_avg_max = ts_max(tv_wall_avg_max,
-					 &counts[i].wall_time_avg);
 
 		sc_name_max = MAX(sc_name_max, strlen(sysent[i].sys_name));
 	}
 	float_tv_cum = ts_float(&tv_cum);
-	float_tv_wall_cum = ts_float(&tv_wall_cum);
+	float_tv_wall_cum = summary_needs_wall() ? ts_float(&tv_wall_cum) : 0;
 
 	if (sortfun)
 		qsort((void *) indices, nsyscalls, sizeof(indices[0]), sortfun);

--- a/src/count.c
+++ b/src/count.c
@@ -25,6 +25,10 @@ struct call_counts {
 	struct timespec time_min;
 	struct timespec time_max;
 	struct timespec time_avg;
+	struct timespec wall_time;
+	struct timespec wall_time_min;
+	struct timespec wall_time_max;
+	struct timespec wall_time_avg;
 	uint64_t calls, errors;
 };
 
@@ -49,6 +53,10 @@ enum count_summary_columns {
 	CSC_CALLS,
 	CSC_ERRORS,
 	CSC_SC_NAME,
+	CSC_TIME_WALL_TOTAL,
+	CSC_TIME_WALL_MIN,
+	CSC_TIME_WALL_MAX,
+	CSC_TIME_WALL_AVG,
 
 	CSC_MAX,
 };
@@ -95,6 +103,22 @@ static const struct {
 	{ "syscall",      CSC_SC_NAME    },
 	{ "syscall_name", CSC_SC_NAME    },
 	{ "syscall-name", CSC_SC_NAME    },
+	{ "wall_total",   CSC_TIME_WALL_TOTAL },
+	{ "wall-total",   CSC_TIME_WALL_TOTAL },
+	{ "total_wall",   CSC_TIME_WALL_TOTAL },
+	{ "total-wall",   CSC_TIME_WALL_TOTAL },
+	{ "wall_min",     CSC_TIME_WALL_MIN   },
+	{ "wall-min",     CSC_TIME_WALL_MIN   },
+	{ "min_wall",     CSC_TIME_WALL_MIN   },
+	{ "min-wall",     CSC_TIME_WALL_MIN   },
+	{ "wall_max",     CSC_TIME_WALL_MAX   },
+	{ "wall-max",     CSC_TIME_WALL_MAX   },
+	{ "max_wall",     CSC_TIME_WALL_MAX   },
+	{ "max-wall",     CSC_TIME_WALL_MAX   },
+	{ "wall_avg",     CSC_TIME_WALL_AVG   },
+	{ "wall-avg",     CSC_TIME_WALL_AVG   },
+	{ "avg_wall",     CSC_TIME_WALL_AVG   },
+	{ "avg-wall",     CSC_TIME_WALL_AVG   },
 	{ "none",         CSC_NONE       },
 	{ "nothing",      CSC_NONE       },
 };
@@ -108,8 +132,10 @@ count_syscall(struct tcb *tcp, const struct timespec *syscall_exiting_ts)
 	if (!counts) {
 		counts = xcalloc(nsyscalls, sizeof(*counts));
 
-		for (size_t i = 0; i < nsyscalls; i++)
+		for (size_t i = 0; i < nsyscalls; i++) {
 			counts[i].time_min = max_ts;
+			counts[i].wall_time_min = max_ts;
+		}
 	}
 	struct call_counts *cc = &counts[tcp->scno];
 
@@ -133,6 +159,16 @@ count_syscall(struct tcb *tcp, const struct timespec *syscall_exiting_ts)
 	ts_add(&cc->time, &cc->time, wts_nonneg);
 	cc->time_min = *ts_min(&cc->time_min, wts_nonneg);
 	cc->time_max = *ts_max(&cc->time_max, wts_nonneg);
+
+	struct timespec wall_wts;
+	ts_sub(&wall_wts, syscall_exiting_ts, &tcp->etime);
+	ts_sub(&wall_wts, &wall_wts, &overhead);
+
+	const struct timespec *wall_wts_nonneg = ts_max(&wall_wts, &zero_ts);
+
+	ts_add(&cc->wall_time, &cc->wall_time, wall_wts_nonneg);
+	cc->wall_time_min = *ts_min(&cc->wall_time_min, wall_wts_nonneg);
+	cc->wall_time_max = *ts_max(&cc->wall_time_max, wall_wts_nonneg);
 }
 
 static int
@@ -162,6 +198,35 @@ avg_time_cmp(const void *a, const void *b)
 {
 	return -ts_cmp(&counts[*((unsigned int *) a)].time_avg,
 		       &counts[*((unsigned int *) b)].time_avg);
+}
+
+static int
+wall_time_cmp(const void *a, const void *b)
+{
+	const unsigned int *a_int = a;
+	const unsigned int *b_int = b;
+	return -ts_cmp(&counts[*a_int].wall_time, &counts[*b_int].wall_time);
+}
+
+static int
+wall_min_time_cmp(const void *a, const void *b)
+{
+	return -ts_cmp(&counts[*((unsigned int *) a)].wall_time_min,
+		       &counts[*((unsigned int *) b)].wall_time_min);
+}
+
+static int
+wall_max_time_cmp(const void *a, const void *b)
+{
+	return -ts_cmp(&counts[*((unsigned int *) a)].wall_time_max,
+		       &counts[*((unsigned int *) b)].wall_time_max);
+}
+
+static int
+wall_avg_time_cmp(const void *a, const void *b)
+{
+	return -ts_cmp(&counts[*((unsigned int *) a)].wall_time_avg,
+		       &counts[*((unsigned int *) b)].wall_time_avg);
 }
 
 static int
@@ -203,14 +268,18 @@ void
 set_sortby(const char *sortby)
 {
 	static const sort_func sort_fns[CSC_MAX] = {
-		[CSC_TIME_100S]  = time_cmp,
-		[CSC_TIME_TOTAL] = time_cmp,
-		[CSC_TIME_MIN]   = min_time_cmp,
-		[CSC_TIME_MAX]   = max_time_cmp,
-		[CSC_TIME_AVG]   = avg_time_cmp,
-		[CSC_CALLS]      = count_cmp,
-		[CSC_ERRORS]     = error_cmp,
-		[CSC_SC_NAME]    = syscall_cmp,
+		[CSC_TIME_100S]       = time_cmp,
+		[CSC_TIME_TOTAL]      = time_cmp,
+		[CSC_TIME_MIN]        = min_time_cmp,
+		[CSC_TIME_MAX]        = max_time_cmp,
+		[CSC_TIME_AVG]        = avg_time_cmp,
+		[CSC_CALLS]           = count_cmp,
+		[CSC_ERRORS]          = error_cmp,
+		[CSC_SC_NAME]         = syscall_cmp,
+		[CSC_TIME_WALL_TOTAL] = wall_time_cmp,
+		[CSC_TIME_WALL_MIN]   = wall_min_time_cmp,
+		[CSC_TIME_WALL_MAX]   = wall_max_time_cmp,
+		[CSC_TIME_WALL_AVG]   = wall_avg_time_cmp,
 	};
 
 	for (size_t i = 0; i < ARRAY_SIZE(column_aliases); ++i) {
@@ -306,10 +375,16 @@ call_summary_pers(FILE *outf)
 	const struct timespec *tv_min_max = &zero_ts;
 	const struct timespec *tv_max = &zero_ts;
 	const struct timespec *tv_avg_max = &zero_ts;
+	struct timespec tv_wall_cum = zero_ts;
+	const struct timespec *tv_wall_min = &max_ts;
+	const struct timespec *tv_wall_min_max = &zero_ts;
+	const struct timespec *tv_wall_max = &zero_ts;
+	const struct timespec *tv_wall_avg_max = &zero_ts;
 	uint64_t call_cum = 0;
 	uint64_t error_cum = 0;
 
 	double float_tv_cum;
+	double float_tv_wall_cum;
 	double percent;
 
 	size_t sc_name_max = 0;
@@ -326,15 +401,25 @@ call_summary_pers(FILE *outf)
 		tv_min = ts_min(tv_min, &counts[i].time_min);
 		tv_min_max = ts_max(tv_min_max, &counts[i].time_min);
 		tv_max = ts_max(tv_max, &counts[i].time_max);
+		ts_add(&tv_wall_cum, &tv_wall_cum, &counts[i].wall_time);
+		tv_wall_min = ts_min(tv_wall_min, &counts[i].wall_time_min);
+		tv_wall_min_max = ts_max(tv_wall_min_max,
+					 &counts[i].wall_time_min);
+		tv_wall_max = ts_max(tv_wall_max, &counts[i].wall_time_max);
 		call_cum += counts[i].calls;
 		error_cum += counts[i].errors;
 
 		ts_div(&counts[i].time_avg, &counts[i].time, counts[i].calls);
 		tv_avg_max = ts_max(tv_avg_max, &counts[i].time_avg);
+		ts_div(&counts[i].wall_time_avg, &counts[i].wall_time,
+		       counts[i].calls);
+		tv_wall_avg_max = ts_max(tv_wall_avg_max,
+					 &counts[i].wall_time_avg);
 
 		sc_name_max = MAX(sc_name_max, strlen(sysent[i].sys_name));
 	}
 	float_tv_cum = ts_float(&tv_cum);
+	float_tv_wall_cum = ts_float(&tv_wall_cum);
 
 	if (sortfun)
 		qsort((void *) indices, nsyscalls, sizeof(indices[0]), sortfun);
@@ -349,15 +434,26 @@ call_summary_pers(FILE *outf)
 		const char *last_fmt;
 		uint32_t flags;
 	} cdesc[] = {
-		[CSC_TIME_100S]  = { ARRSZ_PAIR("% time") - 1,   "%1$*2$.2f" },
-		[CSC_TIME_MIN]   = { ARRSZ_PAIR("shortest") - 1, "%1$*2$.6f" },
-		[CSC_TIME_MAX]   = { ARRSZ_PAIR("longest") - 1,  "%1$*2$.6f" },
+		[CSC_TIME_100S]       = { ARRSZ_PAIR("% time") - 1,
+					  "%1$*2$.2f" },
+		[CSC_TIME_MIN]        = { ARRSZ_PAIR("shortest") - 1,
+					  "%1$*2$.6f" },
+		[CSC_TIME_MAX]        = { ARRSZ_PAIR("longest") - 1,
+					  "%1$*2$.6f" },
 		/* Historical field sizes are preserved */
-		[CSC_TIME_TOTAL] = { "seconds",    11, "%1$*2$.6f" },
-		[CSC_TIME_AVG]   = { "usecs/call", 11, "%1$*2$" PRIu64 },
-		[CSC_CALLS]      = { "calls",       9, "%1$*2$" PRIu64 },
-		[CSC_ERRORS]     = { "errors",      9, "%1$*2$.0" PRIu64 },
-		[CSC_SC_NAME]    = { "syscall",    16, "%1$-*2$s", "%1$s", CF_L },
+		[CSC_TIME_TOTAL]      = { "seconds",    11, "%1$*2$.6f" },
+		[CSC_TIME_AVG]        = { "usecs/call", 11, "%1$*2$" PRIu64 },
+		[CSC_CALLS]           = { "calls",       9, "%1$*2$" PRIu64 },
+		[CSC_ERRORS]          = { "errors",      9,
+					  "%1$*2$.0" PRIu64 },
+		[CSC_SC_NAME]         = { "syscall",    16, "%1$-*2$s",
+					  "%1$s", CF_L },
+		[CSC_TIME_WALL_TOTAL] = { "wall-total", 11, "%1$*2$.6f" },
+		[CSC_TIME_WALL_MIN]   = { ARRSZ_PAIR("wall-min") - 1,
+					  "%1$*2$.6f" },
+		[CSC_TIME_WALL_MAX]   = { ARRSZ_PAIR("wall-max") - 1,
+					  "%1$*2$.6f" },
+		[CSC_TIME_WALL_AVG]   = { "wall-avg",   11, "%1$*2$" PRIu64 },
 	};
 
 	/* calculate column widths */
@@ -375,6 +471,17 @@ call_summary_pers(FILE *outf)
 		W_(CSC_CALLS,      num_chars("%" PRIu64, call_cum)),
 		W_(CSC_ERRORS,     num_chars("%" PRIu64, error_cum)),
 		W_(CSC_SC_NAME,    sc_name_max + 1),
+		W_(CSC_TIME_WALL_TOTAL,
+		   num_chars("%.6f", float_tv_wall_cum)),
+		W_(CSC_TIME_WALL_MIN,
+		   num_chars("%" PRId64 ".000000",
+			     (int64_t) tv_wall_min_max->tv_sec)),
+		W_(CSC_TIME_WALL_MAX,
+		   num_chars("%" PRId64 ".000000",
+			     (int64_t) tv_wall_max->tv_sec)),
+		W_(CSC_TIME_WALL_AVG,
+		   num_chars("%" PRId64,
+			     (uint64_t) (ts_float(tv_wall_avg_max) * 1e6))),
 	};
 #undef W_
 
@@ -427,6 +534,10 @@ call_summary_pers(FILE *outf)
 		FC_(CSC_CALLS);
 		FC_(CSC_ERRORS);
 		FC_(CSC_SC_NAME);
+		FC_(CSC_TIME_WALL_TOTAL);
+		FC_(CSC_TIME_WALL_MIN);
+		FC_(CSC_TIME_WALL_MAX);
+		FC_(CSC_TIME_WALL_AVG);
 		}
 	}
 
@@ -460,6 +571,11 @@ call_summary_pers(FILE *outf)
 			PC_(CSC_CALLS,      cc->calls);
 			PC_(CSC_ERRORS,     cc->errors);
 			PC_(CSC_SC_NAME,    sysent[idx].sys_name);
+			PC_(CSC_TIME_WALL_TOTAL, ts_float(&cc->wall_time));
+			PC_(CSC_TIME_WALL_MIN,   ts_float(&cc->wall_time_min));
+			PC_(CSC_TIME_WALL_MAX,   ts_float(&cc->wall_time_max));
+			PC_(CSC_TIME_WALL_AVG,
+			    (uint64_t) (ts_float(&cc->wall_time_avg) * 1e6));
 			}
 		}
 
@@ -493,6 +609,11 @@ call_summary_pers(FILE *outf)
 		PC_(CSC_CALLS, call_cum);
 		PC_(CSC_ERRORS, error_cum);
 		PC_(CSC_SC_NAME, "total");
+		PC_(CSC_TIME_WALL_TOTAL, float_tv_wall_cum);
+		PC_(CSC_TIME_WALL_MIN, ts_float(tv_wall_min));
+		PC_(CSC_TIME_WALL_MAX, ts_float(tv_wall_max));
+		PC_(CSC_TIME_WALL_AVG,
+		    (uint64_t) (float_tv_wall_cum / call_cum * 1e6));
 		}
 	}
 	fputc('\n', outf);

--- a/tests/count.test
+++ b/tests/count.test
@@ -33,6 +33,8 @@ GENERIC=' *[^ ]+ +0\.0[^n]*nanosleep *'
 WALLCLOCK=' *[^ ]+ +(1\.[01]|0\.99)[^n]*nanosleep *'
 WALLCLOCK1='100\.00 +(1\.[01]|0\.99)[^n]*nanosleep'
 HALFCLOCK=' *[^ ]+ +0\.[567][^n]*nanosleep *'
+WALL_COL=' *(1\.[01]|0\.99)[^n]*nanosleep *'
+WALL_AFTER_CPU=' *0\.[0-9]+ +(1\.[01]|0\.99)[^n]*nanosleep *'
 
 grep_log "$GENERIC"	-c
 grep_log "$GENERIC"	-c -O1
@@ -49,5 +51,10 @@ grep_log "$HALFCLOCK"	-cw -O4.5e-1s -enanosleep
 grep_log "$HALFCLOCK"	-cw --summary-syscall-overhead=4.5e-1s -enanosleep
 grep_log "$HALFCLOCK"	-cw -O456789012ns -enanosleep
 grep_log "$HALFCLOCK"	-cw --summary-syscall-overhead=456789012ns -enanosleep
+grep_log "$WALL_AFTER_CPU"	-c -Utime-total,wall-total,calls,name
+grep_log "$WALL_COL"	-c -Uwall-total,calls,name
+grep_log "$WALL_COL"	-c -Uwall-min,calls,name -enanosleep
+grep_log "$WALL_COL"	-c -Uwall-max,calls,name -enanosleep
+grep_log "$WALL_COL"	-c -Swall-total -Uwall-total,calls,name -enanosleep
 
 exit 0

--- a/tests/options-syntax.test
+++ b/tests/options-syntax.test
@@ -216,7 +216,7 @@ check_e "Requested path \"///\" resolved into \"/\"
 $STRACE_EXE: Requested path \"/.\" resolved into \"/\"
 $STRACE_EXE: -q and -e quiet/--quiet cannot be provided simultaneously" -q --quiet -P /// -P/. .
 
-for i in time time_percent time-percent time_total time-total total_time total-time min_time min-time time_min time-min shortest max_time max-time time_max time-max longest avg_time avg-time time_avg time-avg calls count error errors name syscall syscall_name syscall-name none nothing; do
+for i in time time_percent time-percent time_total time-total total_time total-time min_time min-time time_min time-min shortest max_time max-time time_max time-max longest avg_time avg-time time_avg time-avg wall_total wall-total total_wall total-wall wall_min wall-min min_wall min-wall wall_max wall-max max_wall max-wall wall_avg wall-avg avg_wall avg-wall calls count error errors name syscall syscall_name syscall-name none nothing; do
 	check_h "must have PROG [ARGS] or -p PID" -S "$i"
 	check_h "must have PROG [ARGS] or -p PID" --summary-sort-by="$i"
 	if [ "$i" != none ] && [ "$i" != nothing ]; then
@@ -224,7 +224,7 @@ for i in time time_percent time-percent time_total time-total total_time total-t
 		check_h "must have PROG [ARGS] or -p PID" --summary-only --summary-columns="$i"
 	fi
 done
-for i in time,time_total,avg_time,calls,errors,name time_percent,total_time,time_avg,count,error,syscall_name; do
+for i in time,time_total,avg_time,calls,errors,name time_percent,total_time,time_avg,count,error,syscall_name time-total,wall-total,calls,name wall-total,wall-avg,calls,name; do
 	check_h "must have PROG [ARGS] or -p PID" -c -U "$i"
 	check_h "must have PROG [ARGS] or -p PID" --summary-only --summary-columns="$i"
 done


### PR DESCRIPTION
Closes #327.

Adds wall-clock-aware column aliases (`wall-total`, `wall-min`, `wall-max`, `wall-avg`) to the `-c` summary report. These always read wall-clock data regardless of `-w`, so wall and CPU times can be rendered side by side via `-U` in a single `strace` run instead of two.

Existing column aliases keep their current polymorphic semantics with respect to `-w` (backward compatible).

### Before — two runs required

```
$ strace -c sh -c 'sleep 0.05; head -c 32K /dev/urandom > /dev/null'
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 57.70    0.002521         630         4         2 wait4
 21.01    0.000918          13        68        64 newfstatat
  3.94    0.000172          86         2           vfork
...

$ strace -cw sh -c 'sleep 0.05; head -c 32K /dev/urandom > /dev/null'
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 92.39    0.054119       13529         4         2 wait4
  2.72    0.001591          23        68        64 newfstatat
  1.60    0.000937         468         2           vfork
...
```

Numbers drift between runs because timing is non-deterministic.

### After — one run, both timings

```
$ strace -c -U time-total,wall-total,calls,errors,name -S wall-total \
      sh -c 'sleep 0.05; head -c 32K /dev/urandom > /dev/null'
    seconds  wall-total     calls    errors syscall
----------- ----------- --------- --------- ----------------
   0.003380    0.053591         4         2 wait4
   0.000446    0.001481        68        64 newfstatat
   0.000131    0.000752         2           vfork
   0.000000    0.000289         1           execve
...
```

Same workload, both timings captured. `wait4` ratio (~16× wall/CPU) is now visible directly.

### Tests

`tests/count.test` extended with five new pattern checks covering `-U time-total,wall-total,...`, `-U wall-{total,min,max},...`, and `-S wall-total`. Local run: `count.test` and `count-f.test` PASS.