### PR TITLE
Give a hint about yama if strace -p fails on EPERM

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -2,6 +2,7 @@
 /bpf_attr_check.c
 /config.h
 /config.h.in
+/disable_ptrace
 /disable_ptrace_get_syscall_info
 /disable_ptrace_getregset
 /disable_ptrace_set_syscall_info

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,10 +47,12 @@ strace_LDADD = libstrace.a $(clock_LIBS) $(timer_LIBS) $(termcap_LIBS)
 strace_SOURCES = strace.c
 
 noinst_PROGRAMS = \
+	disable_ptrace	\
 	disable_ptrace_get_syscall_info	\
 	disable_ptrace_getregset	\
 	disable_ptrace_set_syscall_info	\
 	#
+disable_ptrace_LDADD = $(strace_LDADD)
 disable_ptrace_get_syscall_info_LDADD = $(strace_LDADD)
 disable_ptrace_getregset_LDADD = $(strace_LDADD)
 disable_ptrace_set_syscall_info_LDADD = $(strace_LDADD)

--- a/src/disable_ptrace.c
+++ b/src/disable_ptrace.c
@@ -1,0 +1,13 @@
+/*
+ * A helper that executes the specified program
+ * with the ptrace syscall disabled.
+ *
+ * Copyright (c) 2026 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#define DISABLE_PTRACE_ERRNO		EPERM
+#define DEFAULT_PROGRAM_INVOCATION_NAME	"disable_ptrace"
+#include "disable_ptrace_request.c"

--- a/src/disable_ptrace_request.c
+++ b/src/disable_ptrace_request.c
@@ -37,8 +37,11 @@ init(int argc, char **argv)
 	}
 }
 
-#if defined DISABLE_PTRACE_REQUEST \
- && defined PR_SET_NO_NEW_PRIVS \
+#ifndef DISABLE_PTRACE_ERRNO
+# define DISABLE_PTRACE_ERRNO EIO
+#endif
+
+#if defined PR_SET_NO_NEW_PRIVS \
  && defined PR_SET_SECCOMP \
  && defined BPF_JUMP \
  && defined BPF_STMT \
@@ -120,9 +123,13 @@ main(int argc, char **argv)
 			 offsetof(struct seccomp_data, args[0])
 			 + (is_bigendian ? sizeof(uint32_t) : 0)),
 		/* jump to "allow" if it is not equal to DISABLE_PTRACE_REQUEST */
+#ifdef DISABLE_PTRACE_REQUEST
 		BPF_JUMP(BPF_JMP | BPF_K | BPF_JEQ, DISABLE_PTRACE_REQUEST, 0, 1),
+#else
+		BPF_STMT(BPF_JMP | BPF_JA, 0),
+#endif
 		/* reject */
-		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | EIO),
+		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | DISABLE_PTRACE_ERRNO),
 		/* allow */
 		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW)
 	};

--- a/src/strace.c
+++ b/src/strace.c
@@ -1417,14 +1417,41 @@ proc_pid_tracer(int pid)
 	return tracer;
 }
 
-/* Emit diagnostics that may explain why ptrace attach to pid failed with EPERM. */
+/* Returns true if strace holds CAP_SYS_PTRACE. */
+static bool
+has_cap_sys_ptrace(void)
+{
+	static int cached = -1;
+	if (cached >= 0)
+		return cached;
+	FILE *fp = fopen("/proc/self/status", "r");
+	if (!fp)
+		return (cached = 0);
+	char line[256];
+	unsigned long long capeff = 0;
+	while (fgets(line, sizeof(line), fp))
+		if (sscanf(line, "CapEff: %llx", &capeff) == 1)
+			break;
+	fclose(fp);
+	return (cached = (capeff >> 19) & 1); /* CAP_SYS_PTRACE */
+}
+
+/*
+ * Emit diagnostics that may explain why ptrace attach to pid failed
+ * with EPERM.  Checks for an existing tracer, then signal permission.
+ */
 static void
 diagnose_attach_eperm(int pid)
 {
 	int tracer_pid = proc_pid_tracer(pid);
-	if (tracer_pid > 0)
+	if (tracer_pid > 0) {
 		error_msg("Process %d is already being traced by pid %d",
 			  pid, tracer_pid);
+		return;
+	}
+
+	if (!has_cap_sys_ptrace() && my_tkill(pid, 0) < 0 && errno == EPERM)
+		error_msg("process %d may be owned by a different user", pid);
 }
 
 static void

--- a/src/strace.c
+++ b/src/strace.c
@@ -1399,14 +1399,45 @@ process_opt_p_list(char *opt)
 	}
 }
 
+/* Returns tracer pid if pid is already being traced, 0 if not, -1 on error. */
+static int
+proc_pid_tracer(int pid)
+{
+	char path[sizeof("/proc/%d/status") + sizeof(int) * 3];
+	xsprintf(path, "/proc/%d/status", pid);
+	FILE *fp = fopen(path, "r");
+	if (!fp)
+		return -1;
+	char line[256];
+	int tracer = 0;
+	while (fgets(line, sizeof(line), fp))
+		if (sscanf(line, "TracerPid: %d", &tracer) == 1)
+			break;
+	fclose(fp);
+	return tracer;
+}
+
+/* Emit diagnostics that may explain why ptrace attach to pid failed with EPERM. */
+static void
+diagnose_attach_eperm(int pid)
+{
+	int tracer_pid = proc_pid_tracer(pid);
+	if (tracer_pid > 0)
+		error_msg("Process %d is already being traced by pid %d",
+			  pid, tracer_pid);
+}
+
 static void
 attach_tcb(struct tcb *const tcp)
 {
 	const char *ptrace_attach_cmd;
 
 	if (ptrace_attach_or_seize(tcp->pid, &ptrace_attach_cmd) < 0) {
+		int saved_errno = errno;
 		perror_msg("attach: ptrace(%s, %d)",
 			   ptrace_attach_cmd, tcp->pid);
+		if (saved_errno == EPERM)
+			diagnose_attach_eperm(tcp->pid);
 		droptcb(tcp);
 		return;
 	}

--- a/src/strace.c
+++ b/src/strace.c
@@ -1437,8 +1437,32 @@ has_cap_sys_ptrace(void)
 }
 
 /*
+ * If YAMA's ptrace_scope may be blocking the attach, emit a hint.
+ * Scope < 3 only restricts processes without CAP_SYS_PTRACE;
+ * scope 3 blocks all ptrace unconditionally.
+ */
+static void
+hint_yama(void)
+{
+	FILE *fp = fopen("/proc/sys/kernel/yama/ptrace_scope", "r");
+	if (!fp)
+		return;
+	int scope = 0;
+	bool read_ok = fscanf(fp, "%d", &scope) == 1;
+	fclose(fp);
+	if (!read_ok || scope <= 0)
+		return;
+	bool cap = has_cap_sys_ptrace();
+	if (scope < 3 && cap)
+		return;
+	error_msg("sysctl kernel.yama.ptrace_scope = %d"
+		  " may be restricting this attach", scope);
+}
+
+/*
  * Emit diagnostics that may explain why ptrace attach to pid failed
- * with EPERM.  Checks for an existing tracer, then signal permission.
+ * with EPERM.  Checks for an existing tracer, then signal permission;
+ * if neither applies, defers to hint_yama.
  */
 static void
 diagnose_attach_eperm(int pid)
@@ -1450,8 +1474,12 @@ diagnose_attach_eperm(int pid)
 		return;
 	}
 
-	if (!has_cap_sys_ptrace() && my_tkill(pid, 0) < 0 && errno == EPERM)
+	if (!has_cap_sys_ptrace() && my_tkill(pid, 0) < 0 && errno == EPERM) {
 		error_msg("process %d may be owned by a different user", pid);
+		return;
+	}
+
+	hint_yama();
 }
 
 static void

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -646,6 +646,7 @@ MISC_TESTS = \
 	attach-f-p.test \
 	attach-p-cmd.test \
 	attach-p-eperm-already-traced.test \
+	attach-p-eperm-signal.test \
 	bexecve.test \
 	clone_ptrace.test \
 	count-f.test \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -645,6 +645,7 @@ DECODER_TESTS = \
 MISC_TESTS = \
 	attach-f-p.test \
 	attach-p-cmd.test \
+	attach-p-eperm-already-traced.test \
 	bexecve.test \
 	clone_ptrace.test \
 	count-f.test \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -647,6 +647,7 @@ MISC_TESTS = \
 	attach-p-cmd.test \
 	attach-p-eperm-already-traced.test \
 	attach-p-eperm-signal.test \
+	attach-p-eperm-yama.test \
 	bexecve.test \
 	clone_ptrace.test \
 	count-f.test \

--- a/tests/attach-p-eperm-already-traced.test
+++ b/tests/attach-p-eperm-already-traced.test
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Check that strace -p reports an existing tracer when EPERM is due to
+# the target process already being traced.
+#
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+$STRACE -q --trace=none --signal=none -- \
+	sh -c "echo \$\$; sleep $TIMEOUT_DURATION" > "$OUT" 2>/dev/null &
+tracer_pid=$!
+
+while ! [ -s "$OUT" ]; do
+	kill -0 "$tracer_pid" 2>/dev/null ||
+		fail_ "background $STRACE failed to start"
+done
+tracee_pid=$(cat "$OUT")
+
+$STRACE -p "$tracee_pid" 2>"$LOG" &&
+	dump_log_and_fail_with "$STRACE -p $tracee_pid should have failed"
+
+kill "$tracee_pid"
+wait "$tracer_pid" 2>/dev/null
+
+for cmd in PTRACE_SEIZE PTRACE_ATTACH; do
+	cat > "$EXP" <<__EOF__
+$STRACE_EXE: attach: ptrace($cmd, $tracee_pid): Operation not permitted
+$STRACE_EXE: Process $tracee_pid is already being traced by pid $tracer_pid
+__EOF__
+	diff -u -- "$EXP" "$LOG" ||
+		continue
+	exit 0
+done
+dump_log_and_fail_with "unexpected $STRACE -p $tracee_pid output"

--- a/tests/attach-p-eperm-signal.test
+++ b/tests/attach-p-eperm-signal.test
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Check that strace -p reports signal permission denied when the target
+# process cannot be signalled.
+#
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+kill -0 1 2>/dev/null &&
+	skip_ 'can signal PID 1'
+
+tracer1=$(awk '/^TracerPid:/{print $2; exit}' /proc/1/status 2>/dev/null)
+[ "${tracer1:-0}" = 0 ] ||
+	skip_ 'PID 1 is already being traced'
+
+$STRACE -p 1 2>"$LOG" &&
+	dump_log_and_fail_with "$STRACE -p 1 should have failed"
+
+for cmd in PTRACE_SEIZE PTRACE_ATTACH; do
+	grep -qF "$STRACE_EXE: attach: ptrace($cmd, 1): Operation not permitted" "$LOG" ||
+		continue
+	grep -qF "$STRACE_EXE: process 1 may be owned by a different user" "$LOG" ||
+		continue
+	grep -qF 'yama' "$LOG" &&
+		continue
+	exit 0
+done
+dump_log_and_fail_with "unexpected $STRACE -p 1 output"

--- a/tests/attach-p-eperm-yama.test
+++ b/tests/attach-p-eperm-yama.test
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+# Check hint_yama: scope >= 1 prints a hint; scope = 0 and missing file do not.
+#
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+helper='../../src/disable_ptrace'
+$helper true > /dev/null 2>&1 ||
+	skip_ "$helper does not work"
+
+sleep "$TIMEOUT_DURATION" &
+victim_pid=$!
+
+check_eperm() {
+	grep -qE \
+		"attach: ptrace\\(PTRACE_(SEIZE|ATTACH), $victim_pid\\): Operation not permitted" \
+		"$LOG"
+}
+
+# Scenario 1: scope file missing => no YAMA hint
+$STRACE -o "$OUT.trace" --signal=none \
+	-P /proc/sys/kernel/yama/ptrace_scope \
+	--trace=/^open --inject=all:error=ENOENT \
+	"$helper" "$STRACE_EXE" -p "$victim_pid" 2>"$LOG"
+check_eperm ||
+	dump_log_and_fail_with "no ptrace_scope: missing EPERM message"
+grep -qF 'yama' "$LOG" &&
+	dump_log_and_fail_with "no ptrace_scope: unexpected YAMA hint"
+
+# Scenario 2: scope = 0 => no YAMA hint
+echo 0 > "$OUT.scope"
+$STRACE -o "$OUT.trace" --signal=none \
+	-P /proc/sys/kernel/yama/ptrace_scope \
+	--trace=/^open --inject=all:retval=0 \
+	"$helper" "$STRACE_EXE" -p "$victim_pid" < "$OUT.scope" 2>"$LOG"
+check_eperm ||
+	dump_log_and_fail_with "ptrace_scope == 0: missing EPERM message"
+grep -qF 'yama' "$LOG" &&
+	dump_log_and_fail_with "ptrace_scope == 0: unexpected YAMA hint"
+
+# Scenario 3: scope > 0 => YAMA hint emitted
+for i in 1 2 3; do
+	echo $i > "$OUT.scope"
+	$STRACE -o "$OUT.trace" --signal=none \
+		-P /proc/sys/kernel/yama/ptrace_scope \
+		--trace=/^open --inject=all:retval=0 \
+		"$helper" "$STRACE_EXE" -p "$victim_pid" < "$OUT.scope" 2>"$LOG"
+	check_eperm ||
+		dump_log_and_fail_with "ptrace_scope == $i: missing EPERM message"
+	grep -qF "$STRACE_EXE: sysctl kernel.yama.ptrace_scope = $i may be restricting this attach" \
+		"$LOG" ||
+		dump_log_and_fail_with "ptrace_scope == $i: missing YAMA hint"
+done
+
+kill "$victim_pid" 2>/dev/null
+wait "$victim_pid" 2>/dev/null
+exit 0


### PR DESCRIPTION
If strace -p fails on EPERM and the PID matches, the reason is not clean. Give a hint that yama could block it.

It displays the extended message if the error is EPERM and UID is not 0. There are some "false matches" as advanced checks like UID match would require parsing of /proc/$PID/status.