### PR TITLE
Append id to "syscall suspended" lines

### DIFF
--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -141,7 +141,7 @@ Signals are printed as a signal symbol and a decoded
 structure.
 An excerpt from tracing and interrupting the command "sleep 666" is:
 .CW
-sigsuspend([] <unfinished ...>
+sigsuspend([] <unfinished #1 ...>
 --- SIGINT {si_signo=SIGINT, si_code=SI_USER, si_pid=...} ---
 +++ killed by SIGINT +++
 .CE
@@ -153,9 +153,9 @@ will attempt to preserve the order of these events and mark the ongoing call as
 When the call returns, it will be marked as
 .IR resumed .
 .CW
-[pid 28772] select(4, [3], NULL, NULL, NULL <unfinished ...>
+[pid 28772] select(4, [3], NULL, NULL, NULL <unfinished #2 ...>
 [pid 28779] clock_gettime(CLOCK_REALTIME, {tv_sec=1130322148, tv_nsec=3977000}) = 0
-[pid 28772] <... select resumed> )      = 1 (in [3])
+[pid 28772] <... select resumed #2> )      = 1 (in [3])
 .CE
 The interruption of a (restartable) system call by a signal delivery
 is handled differently, as the kernel terminates the system call and

--- a/src/defs.h
+++ b/src/defs.h
@@ -269,6 +269,9 @@ struct tcb {
 # if SUPPORTED_PERSONALITIES > 1
 	unsigned int currpers;	/* Personality at the time of scno update */
 # endif
+	unsigned long resume_id;/* Resumption ID used to keep track of interrupted
+				 * and resumed syscalls.
+				 */
 	unsigned long u_error;	/* Error code */
 	kernel_ulong_t scno;	/* System call number */
 	kernel_ulong_t true_scno;	/* Same, but without subcall decoding and shuffling */

--- a/src/strace.c
+++ b/src/strace.c
@@ -175,6 +175,7 @@ static bool open_append;
 
 struct tcb *printing_tcp;
 static struct tcb *current_tcp;
+static unsigned long resume_id;
 
 struct tcb_wait_data {
 	enum trace_event te; /**< Event passed to dispatch_event() */
@@ -843,6 +844,15 @@ line_ended(void)
 	}
 }
 
+static unsigned long
+update_resume_id(struct tcb *tcp)
+{
+	if (!tcp->resume_id)
+		tcp->resume_id = ++resume_id;
+
+	return tcp->resume_id;
+}
+
 static void
 set_current_tcp(const struct tcb *tcp)
 {
@@ -886,7 +896,7 @@ printleader(struct tcb *tcp)
 			 */
 			set_current_tcp(printing_tcp);
 			tprint_space();
-			tprints_string("<unfinished ...>");
+			tprintf_string("<unfinished #%lu ...>", update_resume_id(printing_tcp));
 			tprint_newline();
 			printing_tcp->curcol = 0;
 		}
@@ -1074,6 +1084,7 @@ alloctcb(int pid)
 			memset(tcp, 0, sizeof(*tcp));
 			list_init(&tcp->wait_list);
 			tcp->pid = pid;
+			tcp->resume_id = 0;
 			maybe_load_task_comm(tcp);
 #if SUPPORTED_PERSONALITIES > 1
 			tcp->currpers = current_personality;
@@ -3437,7 +3448,8 @@ maybe_switch_tcbs(struct tcb *tcp, const int pid)
 		 * Another case is demonstrated by
 		 * tests/maybe_switch_current_tcp.c
 		 */
-		fprintf(execve_thread->outf, " <pid changed to %d ...>\n", pid);
+		fprintf(execve_thread->outf, " <pid changed to %d ... (#%lu)>\n",
+			pid, update_resume_id(execve_thread));
 		/*execve_thread->curcol = 0; - no need, see code below */
 	}
 	/* Swap output FILEs and memstream (needed for -ff) */
@@ -3596,7 +3608,7 @@ print_event_exit(struct tcb *tcp)
 	    && printing_tcp->curcol != 0 && !printing_tcp->staged_output_data) {
 		set_current_tcp(printing_tcp);
 		tprint_space();
-		tprints_string("<unfinished ...>");
+		tprintf_string("<unfinished #%lu ...>", update_resume_id(printing_tcp));
 		tprint_newline();
 		flush_tcp_output(printing_tcp);
 		printing_tcp->curcol = 0;
@@ -3611,6 +3623,10 @@ print_event_exit(struct tcb *tcp)
 		 * on exiting syscall which is not going to happen.
 		 */
 		tprint_space();
+		/*
+		 * resume_id does not have to be printed here since this
+		 * syscall does not require resumption.
+		 */
 		tprints_string("<unfinished ...>");
 	}
 

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -758,7 +758,9 @@ print_syscall_resume(struct tcb *tcp)
 	    || (tcp->flags & TCB_REPRINT)) {
 		tcp->flags &= ~TCB_REPRINT;
 		printleader(tcp);
-		tprintf_string("<... %s resumed>", tcp_sysent(tcp)->sys_name);
+		tprintf_string("<... %s resumed #%lu>", tcp_sysent(tcp)->sys_name, tcp->resume_id);
+		/* Reset resumption ID for this TCB */
+		tcp->resume_id = 0;
 	}
 	printing_tcp = tcp;
 }

--- a/tests/kill_child.test
+++ b/tests/kill_child.test
@@ -22,7 +22,7 @@ while :; do
 	# Printing of "<... SYSCALL resumed>" in strace.c:print_event_exit
 	# used to segfault when the syscall number had not been obtained
 	# on syscall entering.
-	grep -q '^[1-9][0-9]* <\.\.\. ??? resumed>) \+= ?$' "$LOG" && exit 0
+	grep -q '^[1-9][0-9]* <\.\.\. ??? resumed #[1-9][0-9]*>) \+= ?$' "$LOG" && exit 0
 
 	s1="$(date +%s)"
 	if [ "$((s1-s0))" -gt "$((TIMEOUT_DURATION/2))" ]; then

--- a/tests/maybe_switch_current_tcp.c
+++ b/tests/maybe_switch_current_tcp.c
@@ -29,7 +29,7 @@ thread(void *arg)
 	int tid = syscall(__NR_gettid);
 
 	printf("%-5d execveat(AT_FDCWD, \"%s\", [\"%s\", \"%s\", \"%s\"]"
-	       ", NULL, 0 <pid changed to %d ...>\n"
+	       ", NULL, 0 <pid changed to %d ... (#1)>\n"
 #if !QUIET_MSG
 	       "%-5d +++ superseded by execve in pid %d +++\n"
 #endif
@@ -76,7 +76,7 @@ main(int ac, char **av)
 			++trigger;
 	}
 
-	printf("%-5d <... execveat resumed>) = 0\n"
+	printf("%-5d <... execveat resumed #1>) = 0\n"
 	       "%-5d +++ exited with 0 +++\n",
 	       leader, leader);
 	return 0;

--- a/tests/status-detached-threads.c
+++ b/tests/status-detached-threads.c
@@ -27,7 +27,7 @@ thread(void *arg)
 	pid_t pid = getpid();
 	pid_t tid = syscall(__NR_gettid);
 
-	printf("%-5d execve(\"%s\", [\"%s\", \"0\"], NULL <pid changed to %u ...>\n"
+	printf("%-5d execve(\"%s\", [\"%s\", \"0\"], NULL <pid changed to %u ... (#1)>\n"
 	       "%-5d +++ superseded by execve in pid %u +++\n"
 	       "%-5d +++ exited with 0 +++\n",
 	       tid, argv[0], argv[0], pid, pid, tid, pid);

--- a/tests/threads-execve.c
+++ b/tests/threads-execve.c
@@ -129,22 +129,22 @@ thread(void *arg)
 	switch (action % NUMBER_OF_ACTIONS) {
 		case ACTION_exit:
 			printf("%-5d execve(\"%s\", [\"%s\", \"%s\", \"%s\"]"
-			       ", %p /* %u vars */ <pid changed to %u ...>\n",
+			       ", %p /* %u vars */ <pid changed to %u ... (#1)>\n",
 			       tid, argv[0], argv[0], argv[1], argv[2],
 			       environ, arglen(environ), leader);
 			break;
 		case ACTION_rt_sigsuspend:
 			printf("%-5d execve(\"%s\", [\"%s\", \"%s\", \"%s\"]"
-			       ", %p /* %u vars */ <unfinished ...>\n"
-			       "%-5d <... rt_sigsuspend resumed>) = ?\n",
+			       ", %p /* %u vars */ <unfinished #3 ...>\n"
+			       "%-5d <... rt_sigsuspend resumed #2>) = ?\n",
 			       tid, argv[0], argv[0], argv[1], argv[2],
 			       environ, arglen(environ),
 			       leader);
 			break;
 		case ACTION_nanosleep:
 			printf("%-5d execve(\"%s\", [\"%s\", \"%s\", \"%s\"]"
-			       ", %p /* %u vars */ <unfinished ...>\n"
-			       "%-5d <... nanosleep resumed> <unfinished ...>)"
+			       ", %p /* %u vars */ <unfinished #5 ...>\n"
+			       "%-5d <... nanosleep resumed #4> <unfinished ...>)"
 			       " = ?\n",
 			       tid, argv[0], argv[0], argv[1], argv[2],
 			       environ, arglen(environ),
@@ -155,7 +155,7 @@ thread(void *arg)
 # if PRINT_SUPERSEDED
 	printf("%-5d +++ superseded by execve in pid %u +++\n", leader, tid);
 # endif
-	printf("%-5d <... execve resumed>) = 0\n", leader);
+	printf("%-5d <... execve resumed #%u>) = 0\n", leader, 2 * action + 1);
 
 	(void) syscall(__NR_nanosleep, (unsigned long) &ots, 0UL);
 	execve(argv[0], argv, environ);
@@ -220,14 +220,14 @@ main(int ac, char **av)
 			(void) syscall(__NR_exit, 42);
 			break;
 		case ACTION_rt_sigsuspend:
-			printf("%s rt_sigsuspend([], %u <unfinished ...>\n",
+			printf("%s rt_sigsuspend([], %u <unfinished #2 ...>\n",
 			       leader_str, sigsetsize);
 			close(fds[1]);
 			(void) k_sigsuspend(&mask);
 			break;
 		case ACTION_nanosleep:
 			printf("%s nanosleep({tv_sec=%u, tv_nsec=0}"
-			       " <unfinished ...>\n",
+			       " <unfinished #4 ...>\n",
 			       leader_str, (unsigned int) ots.tv_sec);
 			close(fds[1]);
 			(void) syscall(__NR_nanosleep,


### PR DESCRIPTION
While this doesn't print the syscall line in its entirety on resumption, it makes it easier to match suspension-resumption lines when perusing strace's output.

Resolves #152 .