### PR TITLE
Add --hyperlink option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@ Noteworthy changes in release ?.? (????-??-??)
 ==============================================
 
 * Improvements
+  * Implemented --hyperlink option to add hyperlinks from system call names
+    to manual pages on man7.org.
 
 Noteworthy changes in release 7.2 (2026-08-18)
 ==============================================

--- a/doc/strace.1.in
+++ b/doc/strace.1.in
@@ -1159,6 +1159,14 @@ Recognized color keys are:
 .BR retval ,
 .BR error .
 .TP
+.B \-\-hyperlink
+Add hyperlinks from system call names to manual pages at
+.UR https://man7.org/linux/man-pages/man2
+man7.org.
+Note that the hyperlinks are constructed mechanically based on system call names;
+a corresponding manual page may not necessarily exist for every system call
+(e.g. newly added or architecture-specific system calls).
+.TP
 .B \-q
 .TQ
 .B \-\-quiet

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -164,6 +164,8 @@ libstrace_a_SOURCES =	\
 	getrandom.c	\
 	gpio_ioctl.c	\
 	hdio.c		\
+	hyperlink.c	\
+	hyperlink.h	\
 	hostname.c	\
 	inotify.c	\
 	inotify_ioctl.c	\

--- a/src/hyperlink.c
+++ b/src/hyperlink.c
@@ -1,0 +1,43 @@
+/*
+ * Hyperlink support.
+ *
+ * Copyright (c) 2026 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "defs.h"
+#include "hyperlink.h"
+
+#include <string.h>
+
+bool hyperlink_is_enabled = false;
+
+/*
+ * Build a manual page URL on man7.org for a given system call name.
+ * Returns dynamically allocated string, or NULL if not applicable.
+ */
+char *
+make_hyperlink_url_for_syscall(const char *name)
+{
+	if (!name || *name == '?' || !strcmp(name, "system call"))
+		return NULL;
+
+	/*
+	 * Strip architecture/ABI prefixes (such as "n32:", "n64:", "o32:"
+	 * on MIPS) when constructing the manual page URL.
+	 */
+	const char *colon = strchr(name, ':');
+	const char *base_name = colon ? colon + 1 : name;
+
+	/*
+	 * Strip variant suffixes (such as "#64" on x32) when constructing
+	 * the manual page URL.
+	 */
+	const char *hash = strchr(base_name, '#');
+	size_t len = hash ? (size_t) (hash - base_name) : strlen(base_name);
+
+	return xasprintf("https://man7.org/linux/man-pages/man2/%.*s.2.html",
+			 (int) len, base_name);
+}

--- a/src/hyperlink.h
+++ b/src/hyperlink.h
@@ -1,0 +1,25 @@
+/*
+ * Hyperlink support.
+ *
+ * Copyright (c) 2026 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#ifndef STRACE_HYPERLINK_H
+# define STRACE_HYPERLINK_H
+
+# include <stdbool.h>
+
+/*
+ * Terminal hyperlinks using OSC 8 escape sequences:
+ * OSC 8 ; params ; URI ST text OSC 8 ;; ST
+ */
+# define HYPERLINK_FMT	"\033]8;;%s\033\\" "%s" "\033]8;;\033\\"
+
+extern bool hyperlink_is_enabled;
+
+char *make_hyperlink_url_for_syscall(const char *name);
+
+#endif /* STRACE_HYPERLINK_H */

--- a/src/print_fields.c
+++ b/src/print_fields.c
@@ -98,10 +98,19 @@ tprint_array_index_equal(void)
 }
 
 void
+tprints_syscall_name(const char *name)
+{
+	if (!name)
+		name = "system call";
+
+	STRACE_PRINTF("%s", name);
+}
+
+void
 tprints_arg_begin(const char *name)
 {
 	STRACE_PRINT_COLOR_SEQ(COLOR_SYSCALL);
-	STRACE_PRINTF("%s", name);
+	tprints_syscall_name(name);
 	STRACE_PRINT_COLOR_SEQ(COLOR_PUNCT);
 	STRACE_PRINTS("(");
 	STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);

--- a/src/print_fields.c
+++ b/src/print_fields.c
@@ -100,10 +100,24 @@ tprint_array_index_equal(void)
 void
 tprints_syscall_name(const char *name)
 {
-	if (!name)
-		name = "system call";
+	if (!name) {
+		STRACE_PRINTF("%s", "system call");
+		return;
+	}
 
-	STRACE_PRINTF("%s", name);
+	if (!hyperlink_is_enabled) {
+		STRACE_PRINTF("%s", name);
+		return;
+	}
+
+	char *url = make_hyperlink_url_for_syscall(name);
+	if (!url) {
+		STRACE_PRINTF("%s", name);
+		return;
+	}
+
+	STRACE_PRINTF(HYPERLINK_FMT, url, name);
+	free(url);
 }
 
 void

--- a/src/print_fields.h
+++ b/src/print_fields.h
@@ -15,6 +15,7 @@
 # ifdef IN_STRACE
 
 #  include "color.h"
+#  include "hyperlink.h"
 
 #  define STRACE_PRINTS(s_) tprints_string(s_)
 #  define STRACE_PRINT_COLOR_SEQ(kind_) tprint_color_seq(kind_)

--- a/src/print_fields.h
+++ b/src/print_fields.h
@@ -67,6 +67,7 @@ extern void tprint_array_next(void);
 extern void tprint_array_end(void);
 extern void tprint_array_index_begin(void);
 extern void tprint_array_index_equal(void);
+extern void tprints_syscall_name(const char *name);
 extern void tprints_arg_begin(const char *name);
 extern void tprint_arg_next(void);
 extern void tprint_arg_end(void);

--- a/src/signal.c
+++ b/src/signal.c
@@ -831,8 +831,9 @@ SYS_FUNC(rt_sigtimedwait_time64)
 
 SYS_FUNC(restart_syscall)
 {
-	tprintf_string("<... resuming interrupted %s ...>",
-		tcp->s_prev_ent ? tcp->s_prev_ent->sys_name : "system call");
+	tprints_string("<... resuming interrupted ");
+	tprints_syscall_name(tcp->s_prev_ent ? tcp->s_prev_ent->sys_name : NULL);
+	tprints_string(" ...>");
 
 	return RVAL_DECODED;
 }

--- a/src/strace.c
+++ b/src/strace.c
@@ -30,6 +30,7 @@
 
 #include "kill_save_errno.h"
 #include "color.h"
+#include "hyperlink.h"
 #include "exitkill.h"
 #include "filter_seccomp.h"
 #include "largefile_wrappers.h"
@@ -371,6 +372,8 @@ Output format:\n\
                  alignment COLUMN for printing syscall results (default %d)\n\
   --color[=WHEN]\n\
                  colorize output; WHEN is auto, always, or never (default auto)\n\
+  --hyperlink\n\
+                 add hyperlinks from system call names to manual pages at man7.org.\n\
   -e abbrev=SET, --abbrev=SET\n\
                  abbreviate output for the syscalls in SET\n\
   -e verbose=SET, --verbose=SET\n\
@@ -2450,6 +2453,7 @@ init(int argc, char *argv[])
 		GETOPT_STACK_TRACE_FRAME_LIMIT,
 		GETOPT_ALWAYS_SHOW_PID,
 		GETOPT_COLOR,
+		GETOPT_HYPERLINK,
 		GETOPT_QUAL_TRACE,
 		GETOPT_QUAL_TRACE_FD,
 		GETOPT_QUAL_ABBREV,
@@ -2518,6 +2522,7 @@ init(int argc, char *argv[])
 		{ "argv0",		required_argument, 0, GETOPT_ARGV0 },
 		{ "always-show-pid",	no_argument,	   0, GETOPT_ALWAYS_SHOW_PID },
 		{ "color",		required_argument, 0, GETOPT_COLOR },
+		{ "hyperlink",		no_argument,	   0, GETOPT_HYPERLINK },
 		{ "trace",	required_argument, 0, GETOPT_QUAL_TRACE },
 		{ "trace-fds",	required_argument, 0, GETOPT_QUAL_TRACE_FD },
 		{ "abbrev",	required_argument, 0, GETOPT_QUAL_ABBREV },
@@ -2827,6 +2832,9 @@ init(int argc, char *argv[])
 			color_mode = (enum color_mode_t) color_mode_raw;
 			break;
 		}
+		case GETOPT_HYPERLINK:
+			hyperlink_is_enabled = true;
+			break;
 		case GETOPT_QUAL_SECONTEXT:
 			qualify_secontext(optarg ? optarg : secontext_qual);
 			break;

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -755,7 +755,9 @@ print_syscall_resume(struct tcb *tcp)
 	    || (tcp->flags & TCB_REPRINT)) {
 		tcp->flags &= ~TCB_REPRINT;
 		printleader(tcp);
-		tprintf_string("<... %s resumed>", tcp_sysent(tcp)->sys_name);
+		tprints_string("<... ");
+		tprints_syscall_name(tcp_sysent(tcp)->sys_name);
+		tprints_string(" resumed>");
 	}
 	printing_tcp = tcp;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -716,6 +716,7 @@ MISC_TESTS = \
 	status-unfinished-threads.test \
 	strace--color-no-tty.test \
 	strace--color-tty.test \
+	strace--hyperlink.test \
 	strace--argv0.test \
 	strace--syscall-limit.test \
 	strace--syscall-limit--seccomp-bpf.test \

--- a/tests/strace--hyperlink.test
+++ b/tests/strace--hyperlink.test
@@ -1,0 +1,33 @@
+#!/bin/sh -efu
+#
+# Check --hyperlink option
+#
+# Copyright (c) 2026 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. "${srcdir=.}/init.sh"
+
+unset STRACE_COLORS
+unset NO_COLOR
+
+TERM=linux
+export TERM
+
+run_prog ../getpid > /dev/null
+
+csi_color="$(printf '\033\\[')"
+csi_link_begin="$(printf '\033]8;;%s\033\\\\' 'https://man7\.org/linux/man-pages/man2/getpid\.2\.html')"
+csi_link_end="$(printf '\033]8;;\033\\\\')"
+printf '%s\n' ".*${csi_color}33m${csi_link_begin}getpid${csi_link_end}.*${csi_color}0m.*" > "$EXP"
+run_strace --trace=getpid --hyperlink --color=always ../getpid > /dev/null
+match_grep "$LOG" "$EXP"
+
+run_prog ../restart_syscall > /dev/null
+
+csi_link_restart="$(printf '\033]8;;%s\033\\\\' 'https://man7\.org/linux/man-pages/man2/restart_syscall\.2\.html')"
+csi_link_sleep_begin="$(printf '\033]8;;%s\033\\\\' 'https://man7\.org/linux/man-pages/man2/(clock_)?nanosleep(_time64)?\.2\.html')"
+printf '%s\n' "^${csi_link_restart}restart_syscall${csi_link_end}\\(<\\.\\.\\. resuming interrupted ${csi_link_sleep_begin}(clock_)?nanosleep(_time64)?${csi_link_end} \\.\\.\\.>\\) = .*" > "$EXP"
+run_strace --hyperlink ../restart_syscall > /dev/null
+match_grep "$LOG" "$EXP"


### PR DESCRIPTION
Introduce a new command-line option '--hyperlink' to add terminal hyperlinks (using OSC 8 escape sequences) from system call names in the trace output to their corresponding Linux manual pages on man7.org. This improves the diagnostic and educational usability of strace outputs in modern terminals supporting OSC 8.

* NEWS: Mention this change.
* doc/strace.1.in: Document --hyperlink option.
* src/color.h (hyperlink_is_enabled): Declare.
* src/print_fields.c (OSC8_BEGIN, OSC8_END, STRACE_PRINT_SYSCALL): New macros.
(hyperlink_is_enabled): Define.
(tprints_arg_begin): Use STRACE_PRINT_SYSCALL.
* src/strace.c (usage): Document --hyperlink option. (init) <GETOPT_HYPERLINK>: New enum constant.
<longopts>: Add "hyperlink" option.
Handle GETOPT_HYPERLINK.
* tests/Makefile.am (MISC_TESTS): Add strace--hyperlink.test.
* tests/strace--hyperlink.test: New test.

Assisted-by: Antigravity:gemini-3.5-flash (commit log)