### PR TITLE
time: handle dynamic and auxiliary clocks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ Noteworthy changes in release ?.? (????-??-??)
     UFFDIO_SET_MODE userfaultfd ioctls.
   * Updated lists of ATA_*, KVM_*, V4L2_*, and *_MAGIC constants.
   * Fixed dynamic clock id decoding.
+  * Implemented decoding of auxiliary clock IDs.
 
 Noteworthy changes in release 7.2 (2026-08-18)
 ==============================================

--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ Noteworthy changes in release ?.? (????-??-??)
   * Implemented decoding of UFFDIO_MOVE, UFFDIO_RWPROTECT, and
     UFFDIO_SET_MODE userfaultfd ioctls.
   * Updated lists of ATA_*, KVM_*, V4L2_*, and *_MAGIC constants.
+  * Fixed dynamic clock id decoding.
 
 Noteworthy changes in release 7.2 (2026-08-18)
 ==============================================

--- a/bundled/Makefile.am
+++ b/bundled/Makefile.am
@@ -136,6 +136,7 @@ EXTRA_DIST = \
 	linux/include/uapi/linux/tcp_metrics.h \
 	linux/include/uapi/linux/tee.h \
 	linux/include/uapi/linux/thermal.h \
+	linux/include/uapi/linux/time.h \
 	linux/include/uapi/linux/time_types.h \
 	linux/include/uapi/linux/tipc.h \
 	linux/include/uapi/linux/tls.h \

--- a/bundled/linux/include/uapi/linux/time.h
+++ b/bundled/linux/include/uapi/linux/time.h
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+#ifndef _LINUX_TIME_H
+#define _LINUX_TIME_H
+
+#include <linux/types.h>
+#include <linux/time_types.h>
+
+#ifndef _STRUCT_TIMESPEC
+#define _STRUCT_TIMESPEC
+struct timespec {
+	__kernel_old_time_t	tv_sec;		/* seconds */
+	long			tv_nsec;	/* nanoseconds */
+};
+#endif
+
+struct timeval {
+	__kernel_old_time_t	tv_sec;		/* seconds */
+	__kernel_suseconds_t	tv_usec;	/* microseconds */
+};
+
+struct itimerspec {
+	struct timespec it_interval;/* timer period */
+	struct timespec it_value;	/* timer expiration */
+};
+
+struct itimerval {
+	struct timeval it_interval;/* timer interval */
+	struct timeval it_value;	/* current value */
+};
+
+struct timezone {
+	int	tz_minuteswest;	/* minutes west of Greenwich */
+	int	tz_dsttime;	/* type of dst correction */
+};
+
+/*
+ * Names of the interval timers, and structure
+ * defining a timer setting:
+ */
+#define	ITIMER_REAL		0
+#define	ITIMER_VIRTUAL		1
+#define	ITIMER_PROF		2
+
+/*
+ * The IDs of the various system clocks (for POSIX.1b interval timers):
+ */
+#define CLOCK_REALTIME			0
+#define CLOCK_MONOTONIC			1
+#define CLOCK_PROCESS_CPUTIME_ID	2
+#define CLOCK_THREAD_CPUTIME_ID		3
+#define CLOCK_MONOTONIC_RAW		4
+#define CLOCK_REALTIME_COARSE		5
+#define CLOCK_MONOTONIC_COARSE		6
+#define CLOCK_BOOTTIME			7
+#define CLOCK_REALTIME_ALARM		8
+#define CLOCK_BOOTTIME_ALARM		9
+/*
+ * The driver implementing this got removed. The clock ID is kept as a
+ * place holder. Do not reuse!
+ */
+#define CLOCK_SGI_CYCLE			10
+#define CLOCK_TAI			11
+
+#define MAX_CLOCKS			16
+
+/*
+ * AUX clock support. AUXiliary clocks are dynamically configured by
+ * enabling a clock ID. These clock can be steered independently of the
+ * core timekeeper. The kernel can support up to 8 auxiliary clocks, but
+ * the actual limit depends on eventual architecture constraints vs. VDSO.
+ */
+#define CLOCK_AUX			MAX_CLOCKS
+#define MAX_AUX_CLOCKS			8
+#define CLOCK_AUX_LAST			(CLOCK_AUX + MAX_AUX_CLOCKS - 1)
+
+#define CLOCKS_MASK			(CLOCK_REALTIME | CLOCK_MONOTONIC)
+#define CLOCKS_MONO			CLOCK_MONOTONIC
+
+/*
+ * The various flags for setting POSIX.1b interval timers:
+ */
+#define TIMER_ABSTIME			0x01
+
+#endif /* _LINUX_TIME_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -67,6 +67,8 @@ libstrace_a_SOURCES =	\
 	alarm.c		\
 	alpha.c		\
 	arch_defs.h	\
+	auxiliary_clock.c \
+	auxiliary_clock.h \
 	basic_filters.c	\
 	bind.c		\
 	bjm.c		\

--- a/src/auxiliary_clock.c
+++ b/src/auxiliary_clock.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Thomas Weißschuh <thomas.weissschuh@linutronix.de>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <linux/time.h>
+
+#include "auxiliary_clock.h"
+
+bool
+is_auxiliary_clock(int clockid)
+{
+	return clockid >= CLOCK_AUX && clockid <= CLOCK_AUX_LAST;
+}
+
+unsigned int
+auxiliary_clock_num(int clockid)
+{
+	return clockid - CLOCK_AUX;
+}

--- a/src/auxiliary_clock.h
+++ b/src/auxiliary_clock.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Thomas Weißschuh <thomas.weissschuh@linutronix.de>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <stdbool.h>
+
+bool
+is_auxiliary_clock(int clockid);
+
+unsigned int
+auxiliary_clock_num(int clockid);

--- a/src/time.c
+++ b/src/time.c
@@ -256,10 +256,10 @@ printclockname(int clockid)
 		if (xlat_verbose(xlat_verbosity) == XLAT_STYLE_VERBOSE)
 			tprint_comment_begin();
 
-		if ((clockid & CLOCKFD_MASK) == CLOCKFD)
+		if ((clockid & CLOCKFD_MASK) == CLOCKFD) {
 			tprints_fn_begin("FD_TO_CLOCKID");
 			PRINT_VAL_D(CLOCKID_TO_FD(clockid));
-		else {
+		} else {
 			tprints_fn_begin(CPUCLOCK_PERTHREAD(clockid) ?
 					  "MAKE_THREAD_CPUCLOCK" :
 					  "MAKE_PROCESS_CPUCLOCK");

--- a/src/time.c
+++ b/src/time.c
@@ -239,13 +239,24 @@ SYS_FUNC(adjtimex64)
 
 #include "xlat/clockflags.h"
 #include "xlat/clocknames.h"
+#include "xlat/cpuclocknames.h"
+
+#ifndef CLOCKID_TO_FD
+# define CPUCLOCK_PID(clock)		((pid_t) ~((clock) >> 3))
+# define CPUCLOCK_PERTHREAD(clock) \
+	(((clock) & (clockid_t) CPUCLOCK_PERTHREAD_MASK) != 0)
+
+# define CLOCKID_TO_FD(clk)	((unsigned int) ~((clk) >> 3))
+# define CPUCLOCK_CLOCK_MASK	3
+# define CPUCLOCK_PERTHREAD_MASK	4
+# define CLOCKFD_MASK		(CPUCLOCK_PERTHREAD_MASK|CPUCLOCK_CLOCK_MASK)
+# define CPUCLOCK_MAX		3
+# define CLOCKFD			CPUCLOCK_MAX
+#endif
 
 static void
 printclockname(int clockid)
 {
-#ifdef CLOCKID_TO_FD
-# include "xlat/cpuclocknames.h"
-
 	if (clockid < 0) {
 		if (xlat_verbose(xlat_verbosity) != XLAT_STYLE_ABBREV)
 			PRINT_VAL_D(clockid);
@@ -272,8 +283,8 @@ printclockname(int clockid)
 
 		if (xlat_verbose(xlat_verbosity) == XLAT_STYLE_VERBOSE)
 			tprint_comment_end();
+
 	} else
-#endif
 		printxval(clocknames, clockid, "CLOCK_???");
 }
 

--- a/src/time.c
+++ b/src/time.c
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
+#include "auxiliary_clock.h"
 #include "defs.h"
 #include "kernel_fcntl.h"
 #include <signal.h>
@@ -279,6 +280,28 @@ printclockname(int clockid)
 		}
 		tprint_fn_end();
 		tprint_comment_end();
+
+	} else if (is_auxiliary_clock(clockid)) {
+		if (xlat_verbose(xlat_verbosity) != XLAT_STYLE_ABBREV)
+			PRINT_VAL_X(clockid);
+
+		if (xlat_verbose(xlat_verbosity) == XLAT_STYLE_RAW)
+			return;
+
+		if (xlat_verbose(xlat_verbosity) == XLAT_STYLE_VERBOSE)
+			tprint_comment_begin();
+		else
+			STRACE_PRINT_COLOR_SEQ(COLOR_CONST);
+
+		STRACE_PRINTS("CLOCK_AUX");
+
+		if (xlat_verbose(xlat_verbosity) != XLAT_STYLE_VERBOSE)
+			STRACE_PRINT_COLOR_SEQ(COLOR_ARGVAL);
+
+		STRACE_PRINTF(" + %u", auxiliary_clock_num(clockid));
+
+		if (xlat_verbose(xlat_verbosity) == XLAT_STYLE_VERBOSE)
+			tprint_comment_end();
 
 	} else
 		printxval(clocknames, clockid, "CLOCK_???");

--- a/src/time.c
+++ b/src/time.c
@@ -276,7 +276,7 @@ printclockname(int clockid)
 					  "MAKE_PROCESS_CPUCLOCK");
 			PRINT_VAL_D(CPUCLOCK_PID(clockid));
 			tprint_fn_next();
-			printxval(cpuclocknames, clockid & CLOCKFD_MASK,
+			printxval(cpuclocknames, clockid & CPUCLOCK_CLOCK_MASK,
 				  "CPUCLOCK_???");
 		}
 		tprint_fn_end();

--- a/src/time.c
+++ b/src/time.c
@@ -258,14 +258,12 @@ static void
 printclockname(int clockid)
 {
 	if (clockid < 0) {
-		if (xlat_verbose(xlat_verbosity) != XLAT_STYLE_ABBREV)
-			PRINT_VAL_D(clockid);
+		PRINT_VAL_D(clockid);
 
 		if (xlat_verbose(xlat_verbosity) == XLAT_STYLE_RAW)
 			return;
 
-		if (xlat_verbose(xlat_verbosity) == XLAT_STYLE_VERBOSE)
-			tprint_comment_begin();
+		tprint_comment_begin();
 
 		if ((clockid & CLOCKFD_MASK) == CLOCKFD) {
 			tprints_fn_begin("FD_TO_CLOCKID");
@@ -280,9 +278,7 @@ printclockname(int clockid)
 				  "CPUCLOCK_???");
 		}
 		tprint_fn_end();
-
-		if (xlat_verbose(xlat_verbosity) == XLAT_STYLE_VERBOSE)
-			tprint_comment_end();
+		tprint_comment_end();
 
 	} else
 		printxval(clocknames, clockid, "CLOCK_???");

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -946,6 +946,9 @@ preadv-pwritev
 preadv2-pwritev2
 print_maxfd
 print_ppid_tracerpid
+printclockname-Xabbrev
+printclockname-Xraw
+printclockname-Xverbose
 printpath-umovestr
 printpath-umovestr-peekdata
 printpath-umovestr-undumpable

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -373,6 +373,9 @@ check_PROGRAMS = $(PURE_EXECUTABLES) \
 	prctl-tagged-addr-success-Xverbose \
 	print_maxfd \
 	print_ppid_tracerpid \
+	printclockname-Xabbrev \
+	printclockname-Xraw \
+	printclockname-Xverbose \
 	prlimit64--pidns-translation \
 	prlimit64-success \
 	prlimit64-success--pidns-translation \
@@ -906,6 +909,7 @@ EXTRA_DIST = \
 	nlattr_ifla_af_inet6.h \
 	nsyscalls.h \
 	print_user_desc.c \
+	printclockname.c \
 	printsignal.c \
 	printxval.c \
 	process_vm_readv_writev.c \

--- a/tests/gen_tests.in
+++ b/tests/gen_tests.in
@@ -51,7 +51,7 @@ chmod--secontext_mismatch	-a28 --secontext=mismatch -e trace=chmod
 chown	-a28
 chown32	-a31
 chroot	-a13
-clock	test_trace_expr 'times|times-.*|fcntl.*' -e/clock
+clock	test_trace_expr 'times|times-.*|fcntl.*|printclockname-.*' -e/clock
 clock_adjtime	-a37
 clock_adjtime64	-a39
 clock_nanosleep	-e trace=clock_nanosleep,clock_gettime
@@ -940,6 +940,9 @@ pread64-pwrite64	-a21 -eread=0 -ewrite=1 -e trace=pread64,pwrite64 -P pread64-pw
 preadv	-a21
 preadv-pwritev	-a19 -eread=0 -ewrite=1 -e trace=preadv,pwritev
 preadv2-pwritev2	-a22 -eread=0 -ewrite=1 -e trace=preadv2,pwritev2
+printclockname-Xabbrev	-Xabbrev -e trace=clock_getres
+printclockname-Xraw	-Xraw -e trace=clock_getres
+printclockname-Xverbose	-Xverbose -e trace=clock_getres
 printpath-umovestr	-a11 -e signal=none -e trace=chdir
 printpath-umovestr-peekdata	-a11 -e signal=none -e trace=chdir
 printpath-umovestr-undumpable	-a11 -e signal=none -e trace=chdir
@@ -1269,7 +1272,7 @@ times-Xverbose	-esignal=none -e trace=times -Xverbose
 times-fail	-a12 -e trace=times
 tkill	-a12 --signal='!cont'
 tkill--pidns-translation       test_pidns --signal='!cont' -a12 -e trace=tkill
-trace_clock	test_trace_expr 'clock_nanosleep|times|times-.*' -e%clock
+trace_clock	test_trace_expr 'clock_nanosleep|times|times-.*|printclockname-.*' -e%clock
 trace_creds	test_trace_expr '([gs]et[^p]*([gu]id|groups)|caps|prctl|[fl]?chown|print(path-umovestr|strn-umoven)-undumpable|ptrace|quotactl|rt_sigtimedwait|rt_(tg)?sigqueueinfo).*' -e%creds
 trace_fstat	test_trace_expr '' -e%fstat -v -P stat.sample -P /dev/full
 trace_fstatfs	test_trace_expr '' -e%fstatfs
@@ -1282,9 +1285,9 @@ trace_personality_all_x32	+qualify_personality_all.sh x32
 trace_personality_number_32	+qualify_personality.sh 32 "$(${srcdir=.}/print_scno_getcwd.sh)" 'fsync-y|poke'
 trace_personality_number_64	+qualify_personality.sh 64 "$(${srcdir=.}/print_scno_getcwd.sh)" 'fsync-y|poke'
 trace_personality_number_x32	+qualify_personality.sh x32 "$(${srcdir=.}/print_scno_getcwd.sh)" 'fsync-y|poke'
-trace_personality_regex_32	+qualify_personality.sh 32 '/clock.*' 'times|times-.*|fcntl.*'
-trace_personality_regex_64	+qualify_personality.sh 64 '/clock.*' 'times|times-.*|fcntl.*'
-trace_personality_regex_x32	+qualify_personality.sh x32 '/clock.*' 'times|times-.*|fcntl.*'
+trace_personality_regex_32	+qualify_personality.sh 32 '/clock.*' 'times|times-.*|fcntl.*|printclockname-.*'
+trace_personality_regex_64	+qualify_personality.sh 64 '/clock.*' 'times|times-.*|fcntl.*|printclockname-.*'
+trace_personality_regex_x32	+qualify_personality.sh x32 '/clock.*' 'times|times-.*|fcntl.*|printclockname-.*'
 trace_personality_statfs_32	+qualify_personality.sh 32 '%statfs'
 trace_personality_statfs_64	+qualify_personality.sh 64 '%statfs'
 trace_personality_statfs_x32	+qualify_personality.sh x32 '%statfs'

--- a/tests/printclockname-Xabbrev.c
+++ b/tests/printclockname-Xabbrev.c
@@ -1,0 +1,2 @@
+#define XLAT_ABBREV 1
+#include "printclockname.c"

--- a/tests/printclockname-Xraw.c
+++ b/tests/printclockname-Xraw.c
@@ -1,0 +1,2 @@
+#define XLAT_RAW 1
+#include "printclockname.c"

--- a/tests/printclockname-Xverbose.c
+++ b/tests/printclockname-Xverbose.c
@@ -1,0 +1,2 @@
+#define XLAT_VERBOSE 1
+#include "printclockname.c"

--- a/tests/printclockname.c
+++ b/tests/printclockname.c
@@ -1,0 +1,60 @@
+/*
+ * This file is part of clock_xettime* strace tests.
+ *
+ * Copyright (c) 2015-2016 Dmitry V. Levin <ldv@strace.io>
+ * Copyright (c) 2015-2020 The strace developers.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include <linux/time.h>
+#include <linux/unistd.h>
+
+#include "tests.h"
+
+int
+main(void)
+{
+	syscall(__NR_clock_getres, CLOCK_REALTIME, NULL);
+#if XLAT_RAW
+	printf("clock_getres(0, NULL)                   = 0\n");
+#elif XLAT_VERBOSE
+	printf("clock_getres(0 /* CLOCK_REALTIME */, NULL) = 0\n");
+#else
+	printf("clock_getres(CLOCK_REALTIME, NULL)      = 0\n");
+#endif
+
+	syscall(__NR_clock_getres, CLOCK_MONOTONIC, NULL);
+#if XLAT_RAW
+	printf("clock_getres(0x1, NULL)                 = 0\n");
+#elif XLAT_VERBOSE
+	printf("clock_getres(0x1 /* CLOCK_MONOTONIC */, NULL) = 0\n");
+#else
+	printf("clock_getres(CLOCK_MONOTONIC, NULL)     = 0\n");
+#endif
+
+	syscall(__NR_clock_getres, CLOCK_PROCESS_CPUTIME_ID, NULL);
+#if XLAT_RAW
+	printf("clock_getres(0x2, NULL)                 = 0\n");
+#elif XLAT_VERBOSE
+	printf("clock_getres(0x2 /* CLOCK_PROCESS_CPUTIME_ID */, NULL) = 0\n");
+#else
+	printf("clock_getres(CLOCK_PROCESS_CPUTIME_ID, NULL) = 0\n");
+#endif
+
+	syscall(__NR_clock_getres, CLOCK_THREAD_CPUTIME_ID, NULL);
+#if XLAT_RAW
+	printf("clock_getres(0x3, NULL)                 = 0\n");
+#elif XLAT_VERBOSE
+	printf("clock_getres(0x3 /* CLOCK_THREAD_CPUTIME_ID */, NULL) = 0\n");
+#else
+	printf("clock_getres(CLOCK_THREAD_CPUTIME_ID, NULL) = 0\n");
+#endif
+
+	puts("+++ exited with 0 +++");
+	return 0;
+}

--- a/tests/printclockname.c
+++ b/tests/printclockname.c
@@ -99,6 +99,31 @@ main(void)
 	printf("clock_getres(-10 /* MAKE_THREAD_CPUCLOCK(1, CPUCLOCK_SCHED) */, NULL) = -1 EINVAL (Invalid argument)\n");
 #endif
 
+	syscall(__NR_clock_getres, CLOCK_AUX + 0, NULL);
+#if XLAT_RAW
+	printf("clock_getres(0x10, NULL)                = 0\n");
+#elif XLAT_VERBOSE
+	printf("clock_getres(0x10 /* CLOCK_AUX + 0 */, NULL) = 0\n");
+#else
+	printf("clock_getres(CLOCK_AUX + 0, NULL)       = 0\n");
+#endif
+
+	syscall(__NR_clock_getres, CLOCK_AUX + 7, NULL);
+#if XLAT_RAW
+	printf("clock_getres(0x17, NULL)                = 0\n");
+#elif XLAT_VERBOSE
+	printf("clock_getres(0x17 /* CLOCK_AUX + 7 */, NULL) = 0\n");
+#else
+	printf("clock_getres(CLOCK_AUX + 7, NULL)       = 0\n");
+#endif
+
+	syscall(__NR_clock_getres, CLOCK_AUX_LAST + 1, NULL);
+#if XLAT_RAW
+	printf("clock_getres(%#x, NULL)                = -1 EINVAL (Invalid argument)\n", CLOCK_AUX_LAST + 1);
+#else
+	printf("clock_getres(%#x /* CLOCK_??? */, NULL) = -1 EINVAL (Invalid argument)\n", CLOCK_AUX_LAST + 1);
+#endif
+
 	puts("+++ exited with 0 +++");
 	return 0;
 }

--- a/tests/printclockname.c
+++ b/tests/printclockname.c
@@ -98,9 +98,9 @@ main(void)
 #if XLAT_RAW
 	printf("clock_getres(-10, NULL)                 = -1 EINVAL (Invalid argument)\n");
 #elif XLAT_VERBOSE
-	printf("clock_getres(-10 /* MAKE_THREAD_CPUCLOCK(1, 0x6 /* CPUCLOCK_??? */) */, NULL) = -1 EINVAL (Invalid argument)\n");
+	printf("clock_getres(-10 /* MAKE_THREAD_CPUCLOCK(1, 0x2 /* CPUCLOCK_SCHED */) */, NULL) = -1 EINVAL (Invalid argument)\n");
 #else
-	printf("clock_getres(MAKE_THREAD_CPUCLOCK(1, 0x6 /* CPUCLOCK_??? */), NULL) = -1 EINVAL (Invalid argument)\n");
+	printf("clock_getres(MAKE_THREAD_CPUCLOCK(1, CPUCLOCK_SCHED), NULL) = -1 EINVAL (Invalid argument)\n");
 #endif
 
 	puts("+++ exited with 0 +++");

--- a/tests/printclockname.c
+++ b/tests/printclockname.c
@@ -70,19 +70,15 @@ main(void)
 	syscall(__NR_clock_getres, FD_TO_CLOCKID(0), NULL);
 #if XLAT_RAW
 	printf("clock_getres(-5, NULL)                  = -1 EINVAL (Invalid argument)\n");
-#elif XLAT_VERBOSE
-	printf("clock_getres(-5 /* FD_TO_CLOCKID(0) */, NULL) = -1 EINVAL (Invalid argument)\n");
 #else
-	printf("clock_getres(FD_TO_CLOCKID(0), NULL)    = -1 EINVAL (Invalid argument)\n");
+	printf("clock_getres(-5 /* FD_TO_CLOCKID(0) */, NULL) = -1 EINVAL (Invalid argument)\n");
 #endif
 
 	syscall(__NR_clock_getres, FD_TO_CLOCKID(2), NULL);
 #if XLAT_RAW
 	printf("clock_getres(-21, NULL)                 = -1 EINVAL (Invalid argument)\n");
-#elif XLAT_VERBOSE
-	printf("clock_getres(-21 /* FD_TO_CLOCKID(2) */, NULL) = -1 EINVAL (Invalid argument)\n");
 #else
-	printf("clock_getres(FD_TO_CLOCKID(2), NULL)    = -1 EINVAL (Invalid argument)\n");
+	printf("clock_getres(-21 /* FD_TO_CLOCKID(2) */, NULL) = -1 EINVAL (Invalid argument)\n");
 #endif
 
 	syscall(__NR_clock_getres, MAKE_PROCESS_CPUCLOCK(1, CPUCLOCK_VIRT), NULL);
@@ -91,7 +87,7 @@ main(void)
 #elif XLAT_VERBOSE
 	printf("clock_getres(-15 /* MAKE_PROCESS_CPUCLOCK(1, 0x1 /* CPUCLOCK_VIRT */) */, NULL) = 0\n");
 #else
-	printf("clock_getres(MAKE_PROCESS_CPUCLOCK(1, CPUCLOCK_VIRT), NULL) = 0\n");
+	printf("clock_getres(-15 /* MAKE_PROCESS_CPUCLOCK(1, CPUCLOCK_VIRT) */, NULL) = 0\n");
 #endif
 
 	syscall(__NR_clock_getres, MAKE_THREAD_CPUCLOCK(1, CPUCLOCK_SCHED), NULL);
@@ -100,7 +96,7 @@ main(void)
 #elif XLAT_VERBOSE
 	printf("clock_getres(-10 /* MAKE_THREAD_CPUCLOCK(1, 0x2 /* CPUCLOCK_SCHED */) */, NULL) = -1 EINVAL (Invalid argument)\n");
 #else
-	printf("clock_getres(MAKE_THREAD_CPUCLOCK(1, CPUCLOCK_SCHED), NULL) = -1 EINVAL (Invalid argument)\n");
+	printf("clock_getres(-10 /* MAKE_THREAD_CPUCLOCK(1, CPUCLOCK_SCHED) */, NULL) = -1 EINVAL (Invalid argument)\n");
 #endif
 
 	puts("+++ exited with 0 +++");

--- a/tests/printclockname.c
+++ b/tests/printclockname.c
@@ -16,6 +16,18 @@
 
 #include "tests.h"
 
+#define CLOCKFD 3
+#define FD_TO_CLOCKID(fd)   ((~(unsigned int)(clockid_t) (fd) << 3) | CLOCKFD)
+
+#define CPUCLOCK_PERTHREAD_MASK	4
+#define CPUCLOCK_PROF		0
+#define CPUCLOCK_VIRT		1
+#define CPUCLOCK_SCHED		2
+#define MAKE_PROCESS_CPUCLOCK(pid, clock) \
+	((~(unsigned int)(clockid_t) (pid) << 3) | (clockid_t) (clock))
+#define MAKE_THREAD_CPUCLOCK(tid, clock) \
+	MAKE_PROCESS_CPUCLOCK((tid), (clock) | CPUCLOCK_PERTHREAD_MASK)
+
 int
 main(void)
 {
@@ -53,6 +65,42 @@ main(void)
 	printf("clock_getres(0x3 /* CLOCK_THREAD_CPUTIME_ID */, NULL) = 0\n");
 #else
 	printf("clock_getres(CLOCK_THREAD_CPUTIME_ID, NULL) = 0\n");
+#endif
+
+	syscall(__NR_clock_getres, FD_TO_CLOCKID(0), NULL);
+#if XLAT_RAW
+	printf("clock_getres(-5, NULL)                  = -1 EINVAL (Invalid argument)\n");
+#elif XLAT_VERBOSE
+	printf("clock_getres(-5 /* FD_TO_CLOCKID(0) */, NULL) = -1 EINVAL (Invalid argument)\n");
+#else
+	printf("clock_getres(FD_TO_CLOCKID(0), NULL)    = -1 EINVAL (Invalid argument)\n");
+#endif
+
+	syscall(__NR_clock_getres, FD_TO_CLOCKID(2), NULL);
+#if XLAT_RAW
+	printf("clock_getres(-21, NULL)                 = -1 EINVAL (Invalid argument)\n");
+#elif XLAT_VERBOSE
+	printf("clock_getres(-21 /* FD_TO_CLOCKID(2) */, NULL) = -1 EINVAL (Invalid argument)\n");
+#else
+	printf("clock_getres(FD_TO_CLOCKID(2), NULL)    = -1 EINVAL (Invalid argument)\n");
+#endif
+
+	syscall(__NR_clock_getres, MAKE_PROCESS_CPUCLOCK(1, CPUCLOCK_VIRT), NULL);
+#if XLAT_RAW
+	printf("clock_getres(-15, NULL)                 = 0\n");
+#elif XLAT_VERBOSE
+	printf("clock_getres(-15 /* MAKE_PROCESS_CPUCLOCK(1, 0x1 /* CPUCLOCK_VIRT */) */, NULL) = 0\n");
+#else
+	printf("clock_getres(MAKE_PROCESS_CPUCLOCK(1, CPUCLOCK_VIRT), NULL) = 0\n");
+#endif
+
+	syscall(__NR_clock_getres, MAKE_THREAD_CPUCLOCK(1, CPUCLOCK_SCHED), NULL);
+#if XLAT_RAW
+	printf("clock_getres(-10, NULL)                 = -1 EINVAL (Invalid argument)\n");
+#elif XLAT_VERBOSE
+	printf("clock_getres(-10 /* MAKE_THREAD_CPUCLOCK(1, 0x6 /* CPUCLOCK_??? */) */, NULL) = -1 EINVAL (Invalid argument)\n");
+#else
+	printf("clock_getres(MAKE_THREAD_CPUCLOCK(1, 0x6 /* CPUCLOCK_??? */), NULL) = -1 EINVAL (Invalid argument)\n");
 #endif
 
 	puts("+++ exited with 0 +++");

--- a/tests/pure_executables.list
+++ b/tests/pure_executables.list
@@ -668,6 +668,9 @@ pread64-pwrite64
 preadv
 preadv-pwritev
 preadv2-pwritev2
+printclockname-Xabbrev
+printclockname-Xraw
+printclockname-Xverbose
 printpath-umovestr
 printpath-umovestr-peekdata
 printpath-umovestr-undumpable


### PR DESCRIPTION
Linux supports non-standard auxiliary clocks.
These are identified by their clock IDs.