### PR TITLE
bundled: fix build against Linux kernels older than 5.1

### DIFF
--- a/bundled/linux/include/uapi/linux/taskstats.h
+++ b/bundled/linux/include/uapi/linux/taskstats.h
@@ -18,7 +18,9 @@
 #define _LINUX_TASKSTATS_H
 
 #include <linux/types.h>
+#ifndef UAPI_LINUX_TASKSTATS_H_SKIP_LINUX_TIME_TYPES_H
 #include <linux/time_types.h>
+#endif
 
 /* Format for per-task data returned to userland when
  *	- a task exits

--- a/src/netlink_nlctrl.c
+++ b/src/netlink_nlctrl.c
@@ -8,6 +8,8 @@
 #include "defs.h"
 #include "netlink_generic.h"
 #include "nlattr.h"
+#include "kernel_time_types.h"
+#define UAPI_LINUX_TASKSTATS_H_SKIP_LINUX_TIME_TYPES_H
 #include <linux/cgroupstats.h>
 #include <linux/devlink.h>
 #include <linux/ethtool_netlink.h>

--- a/tests/netlink_nlctrl.c
+++ b/tests/netlink_nlctrl.c
@@ -14,6 +14,8 @@
 #include "netlink.h"
 #include "test_netlink.h"
 #include "test_nlattr.h"
+#include "kernel_time_types.h"
+#define UAPI_LINUX_TASKSTATS_H_SKIP_LINUX_TIME_TYPES_H
 #include <linux/genetlink.h>
 #include <linux/cgroupstats.h>
 #include <linux/devlink.h>


### PR DESCRIPTION
Buildroot 2026.05.x fails when targeting linux kernels < 5.1 due to compilation error in `strace` version 7.0. Buildroot HEAD works around this by [disabling strace builds on older kernels.](https://github.com/buildroot/buildroot/blob/master/package/strace/Config.in) Alternatively, we can apply the same backwards-compatibility mechanism used elsewhere in  `strace` and maintain support for older kernels. 

---
Header <linux/time_types.h> was introduced in kernel 5.1 with commit ca5e9aba753e ("time: Add time_types.h").

Apply the same backward-compatibility shim used in io_uring.h allowing callers to replace <linux/time_types.h> with kernel_time_types.h.

* bundled/linux/include/uapi/linux/taskstats.h: Guard with UAPI_LINUX_TASKSTATS_H_SKIP_LINUX_TIME_TYPES_H.
* src/netlink_nlctrl.c: Include kernel_time_types.h and define UAPI_LINUX_TASKSTATS_H_SKIP_LINUX_TIME_TYPES_H.
* tests/netlink_nlctrl.c: Likewise.

Assisted-by: GitHub Copilot:Claude Sonnet 5